### PR TITLE
Fix admin page hook order

### DIFF
--- a/src/pages/AuditLogPage.jsx
+++ b/src/pages/AuditLogPage.jsx
@@ -158,6 +158,7 @@ function AuditEntryRow({ log }) {
 export default function AuditLogPage() {
   const navigate = useNavigate();
   const role = getInternalRole();
+  const isAdmin = getIsAdmin();
 
   const [search, setSearch] = useState('');
   const [filterModule, setFilterModule] = useState('all');
@@ -168,23 +169,15 @@ export default function AuditLogPage() {
   const [sortOrder, setSortOrder] = useState('newest');
   const [showFilters, setShowFilters] = useState(false);
   const [page, setPage] = useState(0);
+  const [actorSearch, setActorSearch] = useState('');
+  const [actorPopoverOpen, setActorPopoverOpen] = useState(false);
   const PAGE_SIZE = 100;
-
-  if (!getIsAdmin()) {
-    return (
-      <AppLayout title="Audit Log">
-        <div className="flex-1 flex items-center justify-center flex-col gap-3">
-          <Shield className="w-8 h-8 text-muted-foreground/30" />
-          <p className="text-sm text-muted-foreground">Admin access required to view the audit log.</p>
-        </div>
-      </AppLayout>
-    );
-  }
 
   const { data: logs = [], isLoading } = useQuery({
     queryKey: ['audit-log-page'],
     queryFn: () => base44.entities.AuditLog.list('-timestamp', 2000),
     staleTime: 30000,
+    enabled: isAdmin,
   });
 
   // Actor options come from structured employee/vendor sources — NOT raw audit log strings.
@@ -193,15 +186,14 @@ export default function AuditLogPage() {
     queryKey: ['employees-for-audit-filter'],
     queryFn: () => base44.entities.Employee.filter({ active: true }),
     staleTime: 60000,
+    enabled: isAdmin,
   });
   const { data: vendors = [] } = useQuery({
     queryKey: ['vendors-for-audit-filter'],
     queryFn: () => base44.entities.Vendor.filter({ active: true }),
     staleTime: 60000,
+    enabled: isAdmin,
   });
-
-  const [actorSearch, setActorSearch] = useState('');
-  const [actorPopoverOpen, setActorPopoverOpen] = useState(false);
 
   // Build curated actor options: employees by name, vendors/subs by company name.
   const actorOptions = useMemo(() => {
@@ -260,6 +252,17 @@ export default function AuditLogPage() {
     if (sortOrder === 'oldest') l = l.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
     return l;
   }, [logs, filterModule, filterSensitive, filterActor, filterDateFrom, filterDateTo, search, sortOrder]);
+
+  if (!isAdmin) {
+    return (
+      <AppLayout title="Audit Log">
+        <div className="flex-1 flex items-center justify-center flex-col gap-3">
+          <Shield className="w-8 h-8 text-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">Admin access required to view the audit log.</p>
+        </div>
+      </AppLayout>
+    );
+  }
 
   const paginated = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE);

--- a/src/pages/DocumentTemplates.jsx
+++ b/src/pages/DocumentTemplates.jsx
@@ -29,22 +29,12 @@ export default function DocumentTemplates() {
   const [templateFile, setTemplateFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const queryClient = useQueryClient();
-
-  if (!isAdminAuthed()) {
-    return (
-      <AppLayout title="Document Templates">
-        <div className="flex-1 flex items-center justify-center flex-col gap-3 px-4">
-          <FileText className="w-10 h-10 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground text-center">Admin access required to manage document templates.</p>
-          <Button variant="outline" className="rounded-xl" onClick={() => window.location.href = '/admin'}>Go to Admin</Button>
-        </div>
-      </AppLayout>
-    );
-  }
+  const isAdmin = isAdminAuthed();
 
   const { data: templates = [], isLoading } = useQuery({
     queryKey: ['doc-templates'],
     queryFn: () => base44.entities.DocumentTemplate.list('-created_date'),
+    enabled: isAdmin,
   });
 
   const saveMutation = useMutation({
@@ -72,6 +62,18 @@ export default function DocumentTemplates() {
     mutationFn: ({ id, active }) => base44.entities.DocumentTemplate.update(id, { active }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['doc-templates'] }),
   });
+
+  if (!isAdmin) {
+    return (
+      <AppLayout title="Document Templates">
+        <div className="flex-1 flex items-center justify-center flex-col gap-3 px-4">
+          <FileText className="w-10 h-10 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground text-center">Admin access required to manage document templates.</p>
+          <Button variant="outline" className="rounded-xl" onClick={() => window.location.href = '/admin'}>Go to Admin</Button>
+        </div>
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout title="Document Templates">

--- a/src/pages/EmployeeManager.jsx
+++ b/src/pages/EmployeeManager.jsx
@@ -30,6 +30,7 @@ export default function EmployeeManager() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const queryClient = useQueryClient();
   const actor = getInternalRole() || 'Admin';
+  const isAdmin = isAdminAuthed();
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
@@ -37,21 +38,10 @@ export default function EmployeeManager() {
     setIsRefreshing(false);
   };
 
-  if (!isAdminAuthed()) {
-    return (
-      <AppLayout title="Employees">
-        <div className="flex-1 flex items-center justify-center flex-col gap-3 px-4">
-          <Users className="w-10 h-10 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground text-center">Admin access required.</p>
-          <Button variant="outline" className="rounded-xl" onClick={() => window.location.href = '/admin'}>Go to Admin</Button>
-        </div>
-      </AppLayout>
-    );
-  }
-
   const { data: employees = [], isLoading } = useQuery({
     queryKey: ['employees'],
     queryFn: () => base44.entities.Employee.list('name'),
+    enabled: isAdmin,
   });
 
   const createMutation = useMutation({
@@ -76,6 +66,18 @@ export default function EmployeeManager() {
     },
     onError: () => toast.error('Failed to update employee status'),
   });
+
+  if (!isAdmin) {
+    return (
+      <AppLayout title="Employees">
+        <div className="flex-1 flex items-center justify-center flex-col gap-3 px-4">
+          <Users className="w-10 h-10 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground text-center">Admin access required.</p>
+          <Button variant="outline" className="rounded-xl" onClick={() => window.location.href = '/admin'}>Go to Admin</Button>
+        </div>
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout title="Employees">


### PR DESCRIPTION
Fixes React hook-order issues in admin pages by moving admin-access early returns below hook declarations and gating protected queries with enabled flags.

Validation reported locally:
- npm.cmd run build passed
- npm.cmd run lint still reports unused-import errors only; previous react-hooks/rules-of-hooks errors are resolved