### PR TITLE
Patch Buildertrend imported jobs to neutral historical state

### DIFF
--- a/base44/entities/Job.jsonc
+++ b/base44/entities/Job.jsonc
@@ -99,6 +99,7 @@
       "type": "string",
       "enum": [
         "presale",
+        "imported",
         "open",
         "in_progress",
         "waiting",
@@ -115,6 +116,7 @@
       "type": "string",
       "enum": [
         "new",
+        "imported",
         "needs_review",
         "needs_scheduling",
         "waiting_homeowner",
@@ -149,10 +151,47 @@
       "enum": [
         "pending",
         "approved",
+        "imported",
         "archived"
       ],
       "default": "pending",
       "description": "Signature approval status"
+    },
+    "requires_signature": {
+      "type": "boolean",
+      "default": true
+    },
+    "signature_required": {
+      "type": "boolean",
+      "default": true
+    },
+    "signature_status": {
+      "type": "string",
+      "enum": [
+        "not_required",
+        "not_requested",
+        "pending",
+        "signed"
+      ],
+      "default": "not_requested"
+    },
+    "needs_attention": {
+      "type": "boolean",
+      "default": false
+    },
+    "attention_needed": {
+      "type": "boolean",
+      "default": false
+    },
+    "approval_status": {
+      "type": "string",
+      "enum": [
+        "imported",
+        "not_required",
+        "pending",
+        "approved",
+        "archived"
+      ]
     },
     "locked": {
       "type": "boolean",
@@ -252,6 +291,24 @@
         "buildertrend"
       ],
       "default": "app"
+    },
+    "sourceSystem": {
+      "type": "string",
+      "enum": [
+        "app",
+        "imported",
+        "manual_entry",
+        "buildertrend"
+      ],
+      "default": "app"
+    },
+    "import_normalized_at": {
+      "type": "string",
+      "description": "ISO timestamp when imported job workflow flags were normalized"
+    },
+    "import_normalized_by": {
+      "type": "string",
+      "description": "Actor who normalized imported job workflow flags"
     },
     "qb_customer_id": {
       "type": "string"

--- a/src/components/admin/DashboardStats.jsx
+++ b/src/components/admin/DashboardStats.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PenLine, CheckCircle2, Star, Archive } from 'lucide-react';
+import { requiresJobSignatureWorkflow } from '@/lib/jobHelpers';
 
 const SECTIONS = [
   { key: 'pending',  label: 'Pending Signatures', icon: PenLine,      color: 'text-amber-500',  bg: 'bg-amber-50' },
@@ -10,7 +11,7 @@ const SECTIONS = [
 
 export default function DashboardStats({ jobs, activeSection, onSelect }) {
   const counts = {
-    pending:  jobs.filter(j => j.status === 'pending').length,
+    pending:  jobs.filter(requiresJobSignatureWorkflow).length,
     approved: jobs.filter(j => j.status === 'approved' && !j.review_rating).length,
     reviewed: jobs.filter(j => j.status === 'approved' && !!j.review_rating).length,
     archived: jobs.filter(j => j.status === 'archived').length,

--- a/src/components/admin/JobsTable.jsx
+++ b/src/components/admin/JobsTable.jsx
@@ -15,10 +15,12 @@ import JobEditModal from './JobEditModal';
 import JobAuditLog from './JobAuditLog';
 import { logAudit } from '@/lib/audit';
 import JobStatusBadge from '../jobs/JobStatusBadge';
+import { isBuildertrendImportedJob } from '@/lib/jobHelpers';
 
 const STATUS_CONFIG = {
   pending:  { label: 'Pending',  icon: Clock,         class: 'bg-secondary text-secondary-foreground' },
   approved: { label: 'Approved', icon: CheckCircle2,  class: 'bg-primary/10 text-primary' },
+  imported: { label: 'Imported', icon: Archive,       class: 'bg-slate-100 text-slate-600' },
   archived: { label: 'Archived', icon: ArchiveX,      class: 'bg-muted text-muted-foreground' },
 };
 
@@ -111,7 +113,8 @@ export default function JobsTable({ jobs, isLoading, role = 'admin', hideFilters
       ) : (
         <div className="space-y-2">
           {(hideFilters ? jobs : filtered).map(job => {
-            const sc = STATUS_CONFIG[job.status] || STATUS_CONFIG.pending;
+            const isBtImported = isBuildertrendImportedJob(job);
+            const sc = isBtImported ? STATUS_CONFIG.imported : (STATUS_CONFIG[job.status] || STATUS_CONFIG.pending);
             const StatusIcon = sc.icon;
             const historyOpen = expandedHistory === job.id;
 
@@ -134,6 +137,11 @@ export default function JobsTable({ jobs, isLoading, role = 'admin', hideFilters
                         <StatusIcon className="w-3 h-3 mr-1" />
                         {sc.label}
                       </Badge>
+                      {isBtImported && (
+                        <Badge className="text-xs bg-slate-100 text-slate-600 border-0">
+                          Buildertrend
+                        </Badge>
+                      )}
                       {isAdminRole && (
                         <>
                           <Button
@@ -191,7 +199,7 @@ export default function JobsTable({ jobs, isLoading, role = 'admin', hideFilters
 
                   {/* Status quick-change + History toggle */}
                   <div className="pl-6 flex items-center justify-between">
-                    {isAdminRole && job.status !== 'archived' ? (
+                    {isAdminRole && job.status !== 'archived' && !isBtImported ? (
                       <Select
                         value={job.status}
                         onValueChange={val => handleStatusChange(job, val)}

--- a/src/components/admin/ReportingPanel.jsx
+++ b/src/components/admin/ReportingPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { base44 } from '@/api/base44Client';
 import { Loader2, FileUp, PenLine, CheckCircle2, Star, MessageSquare, MousePointerClick } from 'lucide-react';
+import { requiresJobSignatureWorkflow } from '@/lib/jobHelpers';
 
 function StatCard({ icon: Icon, label, value, color = 'text-primary', bg = 'bg-secondary' }) {
   return (
@@ -33,7 +34,7 @@ export default function ReportingPanel() {
   }
 
   const totalImported = auditLogs.filter(l => l.action === 'imported_from_csv').length;
-  const pending = jobs.filter(j => j.status === 'pending').length;
+  const pending = jobs.filter(requiresJobSignatureWorkflow).length;
   const signed = jobs.filter(j => j.status === 'approved').length;
   const reviewPromptShown = jobs.filter(j => j.review_prompt_shown).length;
   const googleClicked = jobs.filter(j => j.google_review_clicked).length;

--- a/src/components/btimport/BTStagedJobsTable.jsx
+++ b/src/components/btimport/BTStagedJobsTable.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
 
 function safeJson(str) {

--- a/src/components/dashboard/DashNeedsAttention.jsx
+++ b/src/components/dashboard/DashNeedsAttention.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertCircle, ArrowRight } from 'lucide-react';
-import { getOpStatusConfig } from '@/lib/jobHelpers';
+import { getOpStatusConfig, isBuildertrendImportedJob, requiresJobSignatureWorkflow } from '@/lib/jobHelpers';
 
 const PRIORITY_COLORS = {
   high:   'border-l-red-400 bg-red-50/50',
@@ -30,9 +30,10 @@ function AttentionItem({ label, address, sub, priority = 'medium', onClick }) {
 export default function DashNeedsAttention({ jobs = [], invoices = [], tasks = [], leads = [], bills = [] }) {
   const navigate = useNavigate();
   const items = [];
+  const workflowJobs = jobs.filter(j => !isBuildertrendImportedJob(j));
 
   // Pending signatures — high priority
-  jobs.filter(j => j.status === 'pending').slice(0, 5).forEach(j => items.push({
+  workflowJobs.filter(requiresJobSignatureWorkflow).slice(0, 5).forEach(j => items.push({
     id: `sig-${j.id}`,
     label: 'Needs signature',
     address: j.address,
@@ -53,7 +54,7 @@ export default function DashNeedsAttention({ jobs = [], invoices = [], tasks = [
 
   // Waiting jobs — driven by op_status
   const WAITING_STATUSES = ['waiting_homeowner','waiting_builder','waiting_vendor','waiting_materials','on_hold','needs_scheduling','needs_review'];
-  jobs.filter(j => WAITING_STATUSES.includes(j.op_status || '')).slice(0, 6).forEach(j => {
+  workflowJobs.filter(j => WAITING_STATUSES.includes(j.op_status || '')).slice(0, 6).forEach(j => {
     const cfg = getOpStatusConfig(j.op_status);
     items.push({
       id: `wait-${j.id}`,
@@ -106,7 +107,7 @@ export default function DashNeedsAttention({ jobs = [], invoices = [], tasks = [
   }));
 
   // Jobs explicitly needing scheduling per op_status (avoid duplicates from waiting section)
-  jobs.filter(j => j.op_status === 'needs_scheduling' && !WAITING_STATUSES.includes(j.op_status)).slice(0, 3).forEach(j => items.push({
+  workflowJobs.filter(j => j.op_status === 'needs_scheduling' && !WAITING_STATUSES.includes(j.op_status)).slice(0, 3).forEach(j => items.push({
     id: `sched-${j.id}`,
     label: 'Needs Scheduling',
     address: j.address,

--- a/src/components/jobhub/JobNextStep.jsx
+++ b/src/components/jobhub/JobNextStep.jsx
@@ -20,6 +20,7 @@ import { SIGNATURE_DOCUMENT_MODES } from '@/lib/signatureDocumentModes';
 import DocumentPreviewModal from '@/components/shared/DocumentPreviewModal';
 import { JOB_PRIMARY_ACTIONS, getBestSignedDocR2Key, getBestSignedDocUrl, getJobPrimaryAction } from '@/lib/signedDocHelpers';
 import { buildApprovalPath, ensureSignaturePublicToken } from '@/lib/signingLinks';
+import { isBuildertrendImportedJob } from '@/lib/jobHelpers';
 
 function toR2Ref(key) {
   return key ? `r2://${key}` : '';
@@ -129,6 +130,10 @@ export default function JobNextStep({ job, isAdmin, onGoToSignature }) {
   const fileInputRef = useRef(null);
   const [uploading, setUploading] = useState(false);
   const [previewDoc, setPreviewDoc] = useState(null); // { url, title, docType }
+
+  if (isBuildertrendImportedJob(job)) {
+    return null;
+  }
 
   const primaryAction = getJobPrimaryAction(job, [], { canUploadWorkOrder: isAdmin });
   const step = getStep(job);

--- a/src/components/jobhub/JobSignatureTab.jsx
+++ b/src/components/jobhub/JobSignatureTab.jsx
@@ -16,6 +16,7 @@ import { getSession } from '@/lib/adminAuth';
 import { normalizeSignatureRecordPayload, validateSignatureRecordPayload } from '@/lib/signatureRecords';
 import { JOB_PRIMARY_ACTIONS, isJobSigned, getBestSignedDocUrl, getJobPrimaryAction, hasSourceWorkOrder } from '@/lib/signedDocHelpers';
 import { buildApprovalPath, ensureSignaturePublicToken } from '@/lib/signingLinks';
+import { isBuildertrendImportedJob } from '@/lib/jobHelpers';
 import {
   SIGNATURE_DOCUMENT_MODES,
   SIGNATURE_PLACEMENTS,
@@ -769,6 +770,20 @@ function SignatureRecordCard({ record, isAdmin, onEdit, onDelete, navigate, jobI
 
 // ── Job-level approval summary (from job.status) ──────────────────────────────
 function JobApprovalSummary({ job, records, navigate, onPreview, isAdmin }) {
+  if (isBuildertrendImportedJob(job)) {
+    return (
+      <div className="rounded-xl px-4 py-3 border border-slate-200 bg-slate-50 flex items-start gap-3">
+        <div className="w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center shrink-0 mt-0.5">
+          <Archive className="w-4 h-4 text-slate-600" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-foreground">Buildertrend Imported Record</p>
+          <p className="text-xs text-muted-foreground mt-0.5">Historical import. Signature workflow is not required.</p>
+        </div>
+      </div>
+    );
+  }
+
   const isSigned = isJobSigned(job);
   const isPending = job.status === 'pending';
 

--- a/src/lib/btImportLive.js
+++ b/src/lib/btImportLive.js
@@ -6,6 +6,20 @@
  */
 import { base44 } from '@/api/base44Client';
 
+const BUILDER_TREND_IMPORTED_JOB_FIELDS = {
+  source_system: 'buildertrend',
+  sourceSystem: 'buildertrend',
+  requires_signature: false,
+  signature_required: false,
+  signature_status: 'not_required',
+  needs_attention: false,
+  attention_needed: false,
+  approval_status: 'imported',
+  status: 'imported',
+  lifecycle_status: 'imported',
+  op_status: 'imported',
+};
+
 // ─── Jobs ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -43,9 +57,7 @@ export async function importApprovedJobs(batchId, approvedJobs, actorName) {
         customer_phone: staged.customer_phone || null,
         description:    `Imported from Buildertrend — ${staged.raw_job_name}`,
         price:          0,
-        lifecycle_status: 'open',
-        op_status:      'new',
-        source_system:  'buildertrend',         // ← traceability tag
+        ...BUILDER_TREND_IMPORTED_JOB_FIELDS,
         buildertrend_id: staged.raw_job_name,   // preserve raw BT name as reference ID
         start_date:     staged.received_date || null,
         square_footage: staged.square_footage || null,
@@ -68,6 +80,33 @@ export async function importApprovedJobs(batchId, approvedJobs, actorName) {
   }
 
   return { imported, skipped, errors };
+}
+
+export async function backfillBuildertrendImportedJobs(actorName = 'Admin') {
+  const jobs = await base44.entities.Job.list('-created_date');
+  const candidates = (jobs || []).filter((job) => {
+    const sourceSystem = String(job.source_system || job.sourceSystem || '').toLowerCase();
+    return sourceSystem === 'buildertrend';
+  });
+
+  const updated = [];
+  const errors = [];
+  const now = new Date().toISOString();
+
+  for (const job of candidates) {
+    try {
+      await base44.entities.Job.update(job.id, {
+        ...BUILDER_TREND_IMPORTED_JOB_FIELDS,
+        import_normalized_at: now,
+        import_normalized_by: actorName,
+      });
+      updated.push({ id: job.id, address: job.address || job.title || job.id });
+    } catch (err) {
+      errors.push({ id: job.id, address: job.address || job.title || job.id, error: err?.message || 'Unknown error' });
+    }
+  }
+
+  return { scanned: jobs?.length || 0, matched: candidates.length, updated, errors };
 }
 
 // ─── Daily Logs ───────────────────────────────────────────────────────────────

--- a/src/lib/jobHelpers.js
+++ b/src/lib/jobHelpers.js
@@ -1,5 +1,6 @@
 export const JOB_LIFECYCLE_CONFIG = {
   presale:     { label: 'Presale',     color: 'bg-slate-100 text-slate-600',   border: 'border-slate-200' },
+  imported:    { label: 'Imported',    color: 'bg-slate-100 text-slate-600',   border: 'border-slate-200' },
   open:        { label: 'Open',        color: 'bg-blue-100 text-blue-700',     border: 'border-blue-200' },
   in_progress: { label: 'In Progress', color: 'bg-amber-100 text-amber-700',   border: 'border-amber-200' },
   waiting:     { label: 'Waiting',     color: 'bg-orange-100 text-orange-700', border: 'border-orange-200' },
@@ -15,6 +16,7 @@ export const JOB_LIFECYCLE_CONFIG = {
 // Groups: neutral | attention | waiting | active | paused | financial/done
 export const OP_STATUS_CONFIG = {
   new:               { label: 'New',                  group: 'neutral',    color: 'bg-slate-100 text-slate-600',    dot: 'bg-slate-400' },
+  imported:          { label: 'Imported',             group: 'neutral',    color: 'bg-slate-100 text-slate-600',    dot: 'bg-slate-400' },
   needs_review:      { label: 'Needs Review',         group: 'neutral',    color: 'bg-blue-50 text-blue-700',       dot: 'bg-blue-400' },
   needs_scheduling:  { label: 'Needs Scheduling',     group: 'attention',  color: 'bg-amber-100 text-amber-700',    dot: 'bg-amber-500' },
   waiting_homeowner: { label: 'Waiting on Homeowner', group: 'waiting',    color: 'bg-orange-100 text-orange-700',  dot: 'bg-orange-500' },
@@ -31,7 +33,7 @@ export const OP_STATUS_CONFIG = {
 };
 
 export const OP_STATUS_GROUPS = [
-  { key: 'neutral',   label: 'New / Review',  statuses: ['new', 'needs_review'] },
+  { key: 'neutral',   label: 'New / Review',  statuses: ['new', 'imported', 'needs_review'] },
   { key: 'attention', label: 'Action Needed', statuses: ['needs_scheduling'] },
   { key: 'waiting',   label: 'Waiting',       statuses: ['waiting_homeowner','waiting_builder','waiting_vendor','waiting_materials'] },
   { key: 'active',    label: 'Active',        statuses: ['scheduled','in_progress'] },
@@ -43,7 +45,7 @@ export const OP_STATUS_GROUPS = [
 // Grouped filter buckets for list views
 export const OP_STATUS_FILTER_BUCKETS = [
   { key: 'all',       label: 'All' },
-  { key: 'open',      label: 'Open',      statuses: ['new','needs_review','needs_scheduling','waiting_homeowner','waiting_builder','waiting_vendor','waiting_materials','scheduled','in_progress','on_hold'] },
+  { key: 'open',      label: 'Open',      statuses: ['new','imported','needs_review','needs_scheduling','waiting_homeowner','waiting_builder','waiting_vendor','waiting_materials','scheduled','in_progress','on_hold'] },
   { key: 'waiting',   label: 'Waiting',   statuses: ['waiting_homeowner','waiting_builder','waiting_vendor','waiting_materials'] },
   { key: 'active',    label: 'Active',    statuses: ['scheduled','in_progress'] },
   { key: 'financial', label: 'Financial', statuses: ['invoiced','paid'] },
@@ -77,6 +79,20 @@ export const ACTIVE_LIFECYCLE_STATUSES = ['open','in_progress','waiting','warran
 export const CLOSED_LIFECYCLE_STATUSES = ['completed','closed','archived','canceled'];
 
 // ── Centralized lifecycle helpers ─────────────────────────────────────────────
+
+export function isBuildertrendImportedJob(job) {
+  if (!job) return false;
+  const sourceSystem = String(job.source_system || job.sourceSystem || job.data?.source_system || job.data?.sourceSystem || '').toLowerCase();
+  return sourceSystem === 'buildertrend';
+}
+
+export function requiresJobSignatureWorkflow(job) {
+  if (!job) return false;
+  if (isBuildertrendImportedJob(job)) return false;
+  if (job.requires_signature === false || job.signature_required === false) return false;
+  if (job.signature_status === 'not_required' || job.approval_status === 'imported') return false;
+  return job.status === 'pending';
+}
 
 /** Returns true if the job is considered "active" and should appear in normal selectors */
 export function isActiveJob(job) {

--- a/src/lib/signedDocHelpers.js
+++ b/src/lib/signedDocHelpers.js
@@ -3,6 +3,7 @@
  * Used across JobSearch, JobNextStep, JobSignatureTab, etc.
  */
 import { isStampUploadedPdfMode } from '@/lib/signatureDocumentModes';
+import { isBuildertrendImportedJob } from '@/lib/jobHelpers';
 
 export const JOB_PRIMARY_ACTIONS = Object.freeze({
   UPLOAD_WORK_ORDER: 'upload_work_order',
@@ -20,6 +21,7 @@ export function canUploadWorkOrder(role) {
  * Returns true if the job is considered fully signed/approved.
  */
 export function isJobSigned(job) {
+  if (isBuildertrendImportedJob(job)) return false;
   return job.status === 'approved' || job.status === 'locked';
 }
 
@@ -112,6 +114,15 @@ export function buildSignedDocPreview(job) {
  * Returns the single primary action a non-technical user should see for a job.
  */
 export function getJobPrimaryAction(job, records = [], options = {}) {
+  if (isBuildertrendImportedJob(job)) {
+    return {
+      type: JOB_PRIMARY_ACTIONS.WAITING_ON_WORK_ORDER,
+      label: 'Imported',
+      helperText: 'Buildertrend historical import',
+      disabled: true,
+    };
+  }
+
   const signedDocUrl = getBestSignedDocUrl(job, records);
   const signedDocR2Key = getBestSignedDocR2Key(job, records);
   const canUpload = options.canUploadWorkOrder ?? true;

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -20,11 +20,12 @@ import AccessConfigPanel from '../components/admin/AccessConfigPanel';
 import { toast } from 'sonner';
 import { logAudit } from '@/lib/audit';
 import { format } from 'date-fns';
+import { requiresJobSignatureWorkflow } from '@/lib/jobHelpers';
 
 const emptyJob = { address: '', customer_name: '', description: '', price: '', buildertrend_id: '', email: '', phone: '' };
 
 const SECTION_FILTER = {
-  pending:  j => j.status === 'pending',
+  pending:  requiresJobSignatureWorkflow,
   approved: j => j.status === 'approved' && !j.review_rating,
   reviewed: j => j.status === 'approved' && !!j.review_rating,
   archived: j => j.status === 'archived',

--- a/src/pages/AdminOverview.jsx
+++ b/src/pages/AdminOverview.jsx
@@ -10,6 +10,7 @@ import AppLayout from '../components/AppLayout';
 import { StatCard, SectionHeader } from '../components/dashboard/DashSection';
 import { getInternalRole, isAdmin as getIsAdmin } from '@/lib/adminAuth';
 import { format, parseISO } from 'date-fns';
+import { requiresJobSignatureWorkflow } from '@/lib/jobHelpers';
 
 export default function AdminOverview() {
   const navigate = useNavigate();
@@ -67,7 +68,7 @@ function AdminOverviewContent({ navigate }) {
   const isLoading = loadingJobs || loadingExpenses;
 
   // --- Derived ---
-  const pendingJobs   = useMemo(() => jobs.filter(j => j.status === 'pending'), [jobs]);
+  const pendingJobs   = useMemo(() => jobs.filter(requiresJobSignatureWorkflow), [jobs]);
   const signedJobs    = useMemo(() => jobs.filter(j => j.status === 'approved'), [jobs]);
   const archivedJobs  = useMemo(() => jobs.filter(j => j.lifecycle_status === 'archived'), [jobs]);
 

--- a/src/pages/BTImport.jsx
+++ b/src/pages/BTImport.jsx
@@ -31,7 +31,9 @@ import {
   importApprovedJobs,
   importApprovedDailyLogs,
   importApprovedCalendarEvents,
+  backfillBuildertrendImportedJobs,
 } from '@/lib/btImportLive';
+import { toast } from 'sonner';
 
 // ─── File reading helpers ─────────────────────────────────────────────────────
 
@@ -248,6 +250,19 @@ export default function BTImport() {
   });
 
   // ── Step 1: Parse & Stage ──────────────────────────────────────────────────
+
+  const backfillMutation = useMutation({
+    mutationFn: () => backfillBuildertrendImportedJobs(actorName),
+    onSuccess: (result) => {
+      qc.invalidateQueries({ queryKey: ['jobs'] });
+      qc.invalidateQueries({ queryKey: ['admin-jobs'] });
+      toast.success(`Normalized ${result.updated.length} Buildertrend job${result.updated.length === 1 ? '' : 's'}`);
+      if (result.errors.length) {
+        toast.error(`${result.errors.length} Buildertrend job${result.errors.length === 1 ? '' : 's'} could not be normalized`);
+      }
+    },
+    onError: (err) => toast.error(err?.message || 'Buildertrend cleanup failed'),
+  });
 
   const handleFilesReady = useCallback(async (files) => {
     setParsing(true);
@@ -482,11 +497,25 @@ export default function BTImport() {
             <h1 className="text-xl font-bold text-foreground">Buildertrend Import — Phase 1</h1>
             <p className="text-sm text-muted-foreground mt-0.5">Dry-run staging before any live records are written</p>
           </div>
-          {step !== STEPS.UPLOAD && (
-            <Button variant="outline" className="gap-2 text-sm" onClick={() => { setStep(STEPS.UPLOAD); setStagedJobs([]); setStagedLogs([]); setStagedEvents([]); setImportResult(null); setParseError(''); }}>
-              <RotateCcw className="w-4 h-4" /> New Import
+          <div className="flex items-center gap-2 flex-wrap">
+            <Button
+              variant="outline"
+              className="gap-2 text-sm"
+              onClick={() => backfillMutation.mutate()}
+              disabled={backfillMutation.isPending}
+            >
+              {backfillMutation.isPending
+                ? <Loader2 className="w-4 h-4 animate-spin" />
+                : <Shield className="w-4 h-4" />
+              }
+              Normalize Imported Jobs
             </Button>
-          )}
+            {step !== STEPS.UPLOAD && (
+              <Button variant="outline" className="gap-2 text-sm" onClick={() => { setStep(STEPS.UPLOAD); setStagedJobs([]); setStagedLogs([]); setStagedEvents([]); setImportResult(null); setParseError(''); }}>
+                <RotateCcw className="w-4 h-4" /> New Import
+              </Button>
+            )}
+          </div>
         </div>
 
         {/* Parse error — selectable for copy/paste */}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import DashTodaySchedule from '../components/dashboard/DashTodaySchedule';
 import DashRecentActivity from '../components/dashboard/DashRecentActivity';
 import DashNeedsAttention from '../components/dashboard/DashNeedsAttention';
 import DashFinancialFollowUp from '../components/dashboard/DashFinancialFollowUp';
+import { isBuildertrendImportedJob, requiresJobSignatureWorkflow } from '@/lib/jobHelpers';
 
 // Company/context filter options mapped to job_group values
 const COMPANY_FILTERS = [
@@ -180,9 +181,10 @@ export default function Dashboard() {
   }, [calendarEvents, jobs, companyFilter]);
 
   // ── Attention / urgency counts ────────────────────────────────────────────
-  const pendingSigs  = useMemo(() => filteredJobs.filter(j => j.status === 'pending'), [filteredJobs]);
+  const workflowJobs = useMemo(() => filteredJobs.filter(j => !isBuildertrendImportedJob(j)), [filteredJobs]);
+  const pendingSigs  = useMemo(() => workflowJobs.filter(requiresJobSignatureWorkflow), [workflowJobs]);
   const overdueInvs  = useMemo(() => invoices.filter(i => i.status === 'overdue'), [invoices]);
-  const waitingJobs  = useMemo(() => filteredJobs.filter(j => j.lifecycle_status === 'waiting'), [filteredJobs]);
+  const waitingJobs  = useMemo(() => workflowJobs.filter(j => j.lifecycle_status === 'waiting'), [workflowJobs]);
   const attentionCount = pendingSigs.length + overdueInvs.length + waitingJobs.length;
 
   // ── Financial count badge ─────────────────────────────────────────────────

--- a/src/pages/JobSearch.jsx
+++ b/src/pages/JobSearch.jsx
@@ -12,7 +12,7 @@ import AppLayout from '../components/AppLayout';
 import JobGroupBadge from '../components/jobs/JobGroupBadge';
 import JobStatusBadge from '../components/jobs/JobStatusBadge';
 import { useOfflineCache } from '@/hooks/useOfflineCache';
-import { JOB_GROUP_CONFIG, OP_STATUS_FILTER_BUCKETS } from '@/lib/jobHelpers';
+import { JOB_GROUP_CONFIG, OP_STATUS_FILTER_BUCKETS, isBuildertrendImportedJob } from '@/lib/jobHelpers';
 import DocumentPreviewModal from '@/components/shared/DocumentPreviewModal';
 import { isAdmin as getIsAdmin } from '@/lib/adminAuth';
 import { JOB_PRIMARY_ACTIONS, buildSignedDocPreview, getJobPrimaryAction } from '@/lib/signedDocHelpers';
@@ -28,6 +28,7 @@ const VIEW_TABS = [
 const STATUS_BADGE = {
   pending:  { label: 'Pending',  class: 'bg-amber-50 text-amber-600' },
   approved: { label: 'Signed',   class: 'bg-secondary text-primary' },
+  imported: { label: 'Imported', class: 'bg-slate-100 text-slate-600' },
   archived: { label: 'Archived', class: 'bg-muted text-muted-foreground' },
 };
 
@@ -237,7 +238,8 @@ export default function JobSearch() {
           ) : (
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2">
               {filtered.map((job) => {
-                const badge = STATUS_BADGE[job?.status] || STATUS_BADGE.pending;
+                const isBtImported = isBuildertrendImportedJob(job);
+                const badge = isBtImported ? STATUS_BADGE.imported : (STATUS_BADGE[job?.status] || STATUS_BADGE.pending);
                 const primaryAction = getJobPrimaryAction(job, [], { canUploadWorkOrder });
                 const isSelected = selectedIds.has(job?.id);
                 const isArchived = job?.lifecycle_status === 'archived';
@@ -263,6 +265,7 @@ export default function JobSearch() {
                           <p className="text-sm font-medium text-foreground leading-snug">{job?.address}</p>
                           <div className="flex items-center gap-1 shrink-0">
                             {isArchived && <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">Archived</span>}
+                            {isBtImported && <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-slate-100 text-slate-600">Buildertrend</span>}
                             <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${badge.class}`}>{badge.label}</span>
                           </div>
                         </div>
@@ -278,13 +281,15 @@ export default function JobSearch() {
                         {job?.buildertrend_id && <p className="text-xs text-muted-foreground/60 mt-1">BT# {job.buildertrend_id}</p>}
                         {!selectionMode && (
                           <div className="flex gap-2 mt-2">
-                            <button
-                              onClick={() => handlePrimaryAction(job)}
-                              disabled={primaryAction.disabled}
-                              className="text-xs bg-primary text-primary-foreground px-2.5 py-1 rounded-lg hover:bg-primary/90 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              {primaryAction.label}
-                            </button>
+                            {!isBtImported && (
+                              <button
+                                onClick={() => handlePrimaryAction(job)}
+                                disabled={primaryAction.disabled}
+                                className="text-xs bg-primary text-primary-foreground px-2.5 py-1 rounded-lg hover:bg-primary/90 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                {primaryAction.label}
+                              </button>
+                            )}
                             <button
                               onClick={() => navigate(`/job-hub?jobId=${job.id}`)}
                               className="text-xs bg-muted text-foreground px-2.5 py-1 rounded-lg hover:bg-muted/80 transition-colors"
@@ -301,7 +306,7 @@ export default function JobSearch() {
                             {isSelected ? 'Deselect' : 'Select this job'}
                           </button>
                         )}
-                        {primaryAction.helperText && !selectionMode && (
+                        {primaryAction.helperText && !selectionMode && !isBtImported && (
                           <p className="mt-1.5 text-xs text-muted-foreground">{primaryAction.helperText}</p>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- Treat Buildertrend-imported jobs as historical imported records, not active signature workflows.
- Set imported jobs to neutral signature/attention state.
- Exclude Buildertrend imports from pending-signature and attention-needed counts.
- Show neutral Imported/Buildertrend badges in job list/admin UI.
- Add Normalize Imported Jobs action for already-imported records.
- Preserve records and import metadata.

## Validation
- npm run lint passed
- npm run build passed

## Safety
- Does not touch Cloudflare Worker code.
- Does not touch R2 settings.
- Does not delete or reimport records.