### PR TITLE
Skip already imported Buildertrend jobs during staging

### DIFF
--- a/src/components/btimport/BTDryRunSummary.jsx
+++ b/src/components/btimport/BTDryRunSummary.jsx
@@ -18,8 +18,14 @@ export default function BTDryRunSummary({ stats }) {
           label="Jobsites"
           total={stats.totalJobs}
           items={[
+            { label: `${stats.newJobs || 0} new staged`, warn: false },
+            (stats.alreadyImportedJobs || 0) > 0 && { label: `${stats.alreadyImportedJobs} already imported skipped`, warn: false },
             stats.duplicateJobs > 0 && { label: `${stats.duplicateJobs} possible duplicates`, warn: true },
             stats.flaggedJobs > 0   && { label: `${stats.flaggedJobs} needs review`, warn: true },
+            stats.internalJobs > 0   && { label: `${stats.internalJobs} internal/office/test`, warn: false },
+            stats.missingAddressJobs > 0 && { label: `${stats.missingAddressJobs} missing address`, warn: true },
+            stats.missingClientJobs > 0  && { label: `${stats.missingClientJobs} missing client`, warn: true },
+            { label: `${stats.approvedJobs || 0} approved / ${stats.skippedJobs || 0} skipped`, warn: false },
           ].filter(Boolean)}
         />
         <StatCard

--- a/src/components/btimport/BTStagedJobsTable.jsx
+++ b/src/components/btimport/BTStagedJobsTable.jsx
@@ -15,6 +15,7 @@ const STATUS_BADGE = {
 
 const MATCH_BADGE = {
   new:               { label: 'New',              className: 'bg-primary/10 text-primary' },
+  already_imported:  { label: 'Already Imported', className: 'bg-slate-100 text-slate-600' },
   possible_duplicate:{ label: 'Possible Dup',     className: 'bg-amber-100 text-amber-700' },
   matched_existing:  { label: 'Matches Live Job', className: 'bg-blue-100 text-blue-700' },
   needs_review:      { label: 'Needs Review',     className: 'bg-amber-100 text-amber-700' },
@@ -27,11 +28,11 @@ export default function BTStagedJobsTable({ jobs, onStatusChange }) {
     return <p className="text-sm text-muted-foreground py-6 text-center">No jobsites staged.</p>;
   }
 
-  const pendingCount  = jobs.filter(j => j.review_status === 'pending').length;
+  const pendingCount  = jobs.filter(j => j.review_status === 'pending' && j.match_status !== 'already_imported').length;
   const approvedCount = jobs.filter(j => j.review_status === 'approved').length;
 
   const approveAll = () => jobs
-    .filter(j => j.review_status === 'pending')
+    .filter(j => j.review_status === 'pending' && j.match_status !== 'already_imported')
     .forEach(j => onStatusChange(j.id, 'approved'));
 
   const skipAll = () => jobs
@@ -61,6 +62,7 @@ export default function BTStagedJobsTable({ jobs, onStatusChange }) {
         const flags = safeJson(job.flags);
         const statusBadge = STATUS_BADGE[job.review_status] || STATUS_BADGE.pending;
         const matchBadge  = MATCH_BADGE[job.match_status]   || MATCH_BADGE.new;
+        const isAlreadyImported = job.match_status === 'already_imported';
 
         return (
           <div key={job.id} className="border-t border-border/60">
@@ -92,7 +94,7 @@ export default function BTStagedJobsTable({ jobs, onStatusChange }) {
                 <button
                   onClick={() => onStatusChange(job.id, 'approved')}
                   className={`p-1 rounded transition-colors ${job.review_status === 'approved' ? 'text-green-600' : 'text-muted-foreground hover:text-green-600'}`}
-                  title="Approve"
+                  title={isAlreadyImported ? 'Approve anyway' : 'Approve'}
                 >
                   <CheckCircle2 className="w-4 h-4" />
                 </button>

--- a/src/lib/btImportLive.js
+++ b/src/lib/btImportLive.js
@@ -5,6 +5,7 @@
  * NO live records are created anywhere else in the import pipeline.
  */
 import { base44 } from '@/api/base44Client';
+import { findExistingBuildertrendImportedJob } from '@/lib/jobHelpers';
 
 const BUILDER_TREND_IMPORTED_JOB_FIELDS = {
   source_system: 'buildertrend',
@@ -30,6 +31,7 @@ export async function importApprovedJobs(batchId, approvedJobs, actorName) {
   const imported = [];
   const skipped  = [];
   const errors   = [];
+  const liveJobs = await base44.entities.Job.list('-created_date');
 
   for (const staged of approvedJobs) {
     if (staged.review_status !== 'approved') {
@@ -44,6 +46,22 @@ export async function importApprovedJobs(batchId, approvedJobs, actorName) {
     }
 
     try {
+      const existingJob = findExistingBuildertrendImportedJob(staged, liveJobs);
+      if (existingJob) {
+        skipped.push({
+          stagedId: staged.id,
+          liveId: existingJob.id,
+          address: existingJob.address || staged.address,
+          reason: 'Already imported from Buildertrend',
+        });
+        await base44.entities.StagedJob.update(staged.id, {
+          match_status: 'already_imported',
+          matched_job_id: existingJob.id,
+          review_status: 'skipped',
+        });
+        continue;
+      }
+
       const address = [staged.address, staged.city, staged.state].filter(Boolean).join(', ');
 
       const job = await base44.entities.Job.create({
@@ -65,6 +83,8 @@ export async function importApprovedJobs(batchId, approvedJobs, actorName) {
         internal_notes: `BT Import batch: ${batchId} | staged_id: ${staged.id} | imported by: ${actorName}`,
         assigned_to:    actorName,
       });
+
+      liveJobs.push(job);
 
       // Update staged record with live ID
       await base44.entities.StagedJob.update(staged.id, {

--- a/src/lib/jobHelpers.js
+++ b/src/lib/jobHelpers.js
@@ -86,6 +86,78 @@ export function isBuildertrendImportedJob(job) {
   return sourceSystem === 'buildertrend';
 }
 
+export function normalizeBuildertrendMatchValue(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^\w\s#-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeAddressParts(...parts) {
+  return normalizeBuildertrendMatchValue(parts.filter(Boolean).join(' '));
+}
+
+export function findExistingBuildertrendImportedJob(stagedJob, liveJobs = []) {
+  if (!stagedJob) return null;
+
+  const importedJobs = (liveJobs || []).filter(isBuildertrendImportedJob);
+  const stagedBtId = normalizeBuildertrendMatchValue(stagedJob.buildertrend_id || stagedJob.raw_job_name);
+  const stagedRawName = normalizeBuildertrendMatchValue(stagedJob.raw_job_name);
+  const stagedCleanName = normalizeBuildertrendMatchValue(stagedJob.clean_job_name || stagedJob.raw_job_name);
+  const stagedAddress = normalizeAddressParts(stagedJob.address);
+  const stagedCity = normalizeBuildertrendMatchValue(stagedJob.city);
+  const stagedState = normalizeBuildertrendMatchValue(stagedJob.state);
+  const stagedZip = normalizeBuildertrendMatchValue(stagedJob.zip);
+  const stagedFullAddress = normalizeAddressParts(stagedJob.address, stagedJob.city, stagedJob.state, stagedJob.zip);
+  const addressMatches = (liveAddress) => (
+    liveAddress === stagedAddress ||
+    liveAddress === stagedFullAddress ||
+    Boolean(stagedAddress && liveAddress.startsWith(`${stagedAddress} `))
+  );
+
+  if (stagedBtId) {
+    const match = importedJobs.find((job) =>
+      normalizeBuildertrendMatchValue(job.buildertrend_id || job.buildertrendId) === stagedBtId
+    );
+    if (match) return match;
+  }
+
+  if (stagedRawName) {
+    const match = importedJobs.find((job) =>
+      normalizeBuildertrendMatchValue(job.buildertrend_id || job.buildertrendId || job.raw_job_name || job.title) === stagedRawName
+    );
+    if (match) return match;
+  }
+
+  if (stagedCleanName && stagedAddress) {
+    const match = importedJobs.find((job) => {
+      const liveName = normalizeBuildertrendMatchValue(job.clean_job_name || job.title || job.buildertrend_id || job.buildertrendId);
+      const liveAddress = normalizeAddressParts(job.address);
+      return liveName === stagedCleanName && addressMatches(liveAddress);
+    });
+    if (match) return match;
+  }
+
+  if (stagedAddress && stagedCity && stagedState && stagedZip) {
+    const match = importedJobs.find((job) => {
+      const liveAddress = normalizeAddressParts(job.address);
+      const liveFullAddress = normalizeAddressParts(job.address, job.city, job.state, job.zip);
+      const liveCity = normalizeBuildertrendMatchValue(job.city);
+      const liveState = normalizeBuildertrendMatchValue(job.state);
+      const liveZip = normalizeBuildertrendMatchValue(job.zip);
+      return (
+        liveFullAddress === stagedFullAddress ||
+        liveAddress === stagedFullAddress ||
+        (addressMatches(liveAddress) && liveCity === stagedCity && liveState === stagedState && liveZip === stagedZip)
+      );
+    });
+    if (match) return match;
+  }
+
+  return null;
+}
+
 export function requiresJobSignatureWorkflow(job) {
   if (!job) return false;
   if (isBuildertrendImportedJob(job)) return false;

--- a/src/pages/BTImport.jsx
+++ b/src/pages/BTImport.jsx
@@ -27,6 +27,7 @@ import {
   matchLogsToJobs,
   matchEventsToJobs,
 } from '@/lib/btParsers';
+import { findExistingBuildertrendImportedJob } from '@/lib/jobHelpers';
 import {
   importApprovedJobs,
   importApprovedDailyLogs,
@@ -222,6 +223,25 @@ function parseJobsitesCsv(file) {
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
+function addWarning(job, warning) {
+  const warnings = safeParseJson(job.warnings, []);
+  return JSON.stringify(warnings.includes(warning) ? warnings : [...warnings, warning]);
+}
+
+function markAlreadyImportedJobs(stagedJobs, liveJobs) {
+  return stagedJobs.map((job) => {
+    const match = findExistingBuildertrendImportedJob(job, liveJobs);
+    if (!match) return job;
+    return {
+      ...job,
+      match_status: 'already_imported',
+      matched_job_id: match.id || null,
+      review_status: 'skipped',
+      warnings: addWarning(job, 'Already imported from Buildertrend'),
+    };
+  });
+}
+
 const STEPS = { UPLOAD: 'upload', DRY_RUN: 'dry_run', CONFIRM: 'confirm', DONE: 'done' };
 
 export default function BTImport() {
@@ -296,7 +316,8 @@ export default function BTImport() {
       if (files.jobsites) {
         const { rows, debugInfo } = await parseJobsitesCsv(files.jobsites);
         const result = parseJobsiteRows(rows, batch.id, files.jobsites.name);
-        jobs = result.staged;
+        const liveJobs = await base44.entities.Job.list('-created_date');
+        jobs = markAlreadyImportedJobs(result.staged, liveJobs);
         allErrors.push(...result.errors.map(e => `[Jobs] ${e}`));
 
         // ── Parser diagnostics summary (always shown) ─────────────────────────
@@ -417,7 +438,7 @@ export default function BTImport() {
     try {
       await base44.entities.ImportBatch.update(currentBatchId, { import_status: 'in_progress' });
 
-      const approvedJobs   = stagedJobs.filter(j => j.review_status === 'approved');
+      const approvedJobs   = stagedJobs.filter(j => j.review_status === 'approved' && j.match_status !== 'already_imported');
       const approvedLogs   = stagedLogs.filter(l => l.review_status === 'approved');
       const approvedEvents = stagedEvents.filter(e => e.review_status === 'approved');
 
@@ -456,8 +477,15 @@ export default function BTImport() {
 
   const stats = {
     totalJobs:      stagedJobs.length,
+    newJobs:        stagedJobs.filter(j => j.match_status === 'new').length,
+    alreadyImportedJobs: stagedJobs.filter(j => j.match_status === 'already_imported').length,
     duplicateJobs:  stagedJobs.filter(j => j.match_status === 'possible_duplicate').length,
     flaggedJobs:    stagedJobs.filter(j => j.match_status === 'needs_review').length,
+    internalJobs:   stagedJobs.filter(j => safeParseJson(j.flags, []).includes('internal_record')).length,
+    missingAddressJobs: stagedJobs.filter(j => safeParseJson(j.flags, []).includes('missing_address')).length,
+    missingClientJobs: stagedJobs.filter(j => safeParseJson(j.flags, []).includes('missing_client')).length,
+    approvedJobs:   stagedJobs.filter(j => j.review_status === 'approved').length,
+    skippedJobs:    stagedJobs.filter(j => j.review_status === 'skipped').length,
     totalLogs:      stagedLogs.length,
     unmatchedLogs:  stagedLogs.filter(l => l.match_status === 'unmatched').length,
     attachmentLogs: stagedLogs.filter(l => l.needs_attachment_review).length,


### PR DESCRIPTION
## Summary
- Detect Buildertrend jobs that were already imported during Jobsites dry-run.
- Default already-imported matches to skipped so repeated exports do not create duplicates.
- Keep already-imported exact matches separate from possible duplicates.
- Exclude already-imported rows from Approve All.
- Add a live import guard to avoid duplicate Job creation.

## Validation
- npm run lint
- npm run build

## Safety
- Does not touch Cloudflare Worker code.
- Does not touch R2 settings.
- Does not delete existing jobs.
- Does not modify existing imported jobs except reading them for duplicate detection.