### PR TITLE
Add Daily Logs TXT parser

### DIFF
--- a/src/components/btimport/BTDryRunSummary.jsx
+++ b/src/components/btimport/BTDryRunSummary.jsx
@@ -33,6 +33,7 @@ export default function BTDryRunSummary({ stats }) {
           label="Daily Logs"
           total={stats.totalLogs}
           items={[
+            stats.matchedLogs > 0    && { label: `${stats.matchedLogs} matched to job`, warn: false },
             stats.unmatchedLogs > 0  && { label: `${stats.unmatchedLogs} unmatched to job`, warn: true },
             stats.attachmentLogs > 0 && { label: `${stats.attachmentLogs} have attachments`, warn: false },
           ].filter(Boolean)}

--- a/src/lib/btParsers.js
+++ b/src/lib/btParsers.js
@@ -14,6 +14,42 @@ function safeJson(arr) {
   try { return JSON.stringify(arr); } catch { return '[]'; }
 }
 
+const MONTHS = {
+  jan: '01', january: '01',
+  feb: '02', february: '02',
+  mar: '03', march: '03',
+  apr: '04', april: '04',
+  may: '05',
+  jun: '06', june: '06',
+  jul: '07', july: '07',
+  aug: '08', august: '08',
+  sep: '09', sept: '09', september: '09',
+  oct: '10', october: '10',
+  nov: '11', november: '11',
+  dec: '12', december: '12',
+};
+
+const DATE_HEADING_RE = /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2}),\s+(\d{4})$/i;
+
+function parseDateHeading(line) {
+  const match = String(line || '').trim().match(DATE_HEADING_RE);
+  if (!match) return null;
+  const month = MONTHS[match[1].toLowerCase()];
+  if (!month) return null;
+  return `${match[3]}-${month}-${String(match[2]).padStart(2, '0')}`;
+}
+
+function isLabelLine(line, label) {
+  return String(line || '').trim().toLowerCase() === label.toLowerCase();
+}
+
+function nextNonEmptyIndex(lines, start) {
+  for (let i = start; i < lines.length; i++) {
+    if (String(lines[i] || '').trim()) return i;
+  }
+  return -1;
+}
+
 /**
  * BT job names often start with a date prefix like "2026 4/24 4008 Braid Ct"
  * or "04/24/2026 Smith Residence". Strip leading date tokens.
@@ -204,7 +240,7 @@ export function parseJobsiteRows(rows, batchId, fileName) {
  * Parse a plain-text Buildertrend Daily Log export.
  * Logs are separated by blank lines; each block starts with "Date: " and "Job: ".
  */
-export function parseDailyLogText(text, batchId, fileName) {
+function parseDailyLogTextLegacy(text, batchId, fileName) {
   const staged = [];
   const errors = [];
 
@@ -402,6 +438,7 @@ export function matchLogsToJobs(stagedLogs, stagedJobs) {
   const jobIndex = new Map(stagedJobs.map(j => [j.normalized_job_name, j]));
 
   return stagedLogs.map(log => {
+    if (log.match_status && log.match_status !== 'unmatched') return log;
     const norm = log.normalized_job_name;
     if (!norm) return log;
     const match = jobIndex.get(norm);
@@ -434,4 +471,156 @@ export function matchEventsToJobs(stagedEvents, stagedJobs) {
     }
     return ev;
   });
+}
+
+export function parseDailyLogText(text, batchId, fileName) {
+  const staged = [];
+  const errors = [];
+  const parserUsed = 'manual Daily Logs text parser';
+  const rawLines = String(text || '').replace(/\r\n?/g, '\n').split('\n');
+  const nonEmptyLines = rawLines.map(line => line.trim()).filter(Boolean);
+  const detectedDateHeadings = nonEmptyLines.filter(line => parseDateHeading(line));
+  const jobLabelCount = nonEmptyLines.filter(line => isLabelLine(line, 'Job:')).length;
+  const first40Lines = rawLines.slice(0, 40).map((line, index) => `${index + 1}: ${line}`).join('\n');
+
+  const buildDiagnostics = () => ({
+    parser: parserUsed,
+    totalBlocks: 0,
+    stagedCount: staged.length,
+    matchedCount: 0,
+    unmatchedCount: staged.length,
+    attachmentReviewCount: staged.filter(log => log.needs_attachment_review).length,
+    first5Jobs: staged.slice(0, 5).map(log => log.source_job_name || '(no job name)'),
+    first3UnmatchedJobs: staged.slice(0, 3).map(log => log.source_job_name || '(no job name)'),
+    detectedDateHeadings,
+    jobLabelCount,
+    first40Lines,
+  });
+
+  if (!text || !text.trim()) {
+    errors.push('Empty daily log file');
+    return { staged, errors, diagnostics: buildDiagnostics() };
+  }
+
+  const starts = [];
+  for (let i = 0; i < nonEmptyLines.length; i++) {
+    if (!parseDateHeading(nonEmptyLines[i])) continue;
+    const nextIndex = nextNonEmptyIndex(nonEmptyLines, i + 1);
+    if (nextIndex >= 0 && isLabelLine(nonEmptyLines[nextIndex], 'Job:')) {
+      starts.push(i);
+    }
+  }
+
+  if (starts.length === 0) {
+    const legacy = parseDailyLogTextLegacy(text, batchId, fileName);
+    if (legacy.staged.length > 0) {
+      return {
+        ...legacy,
+        diagnostics: {
+          ...buildDiagnostics(),
+          parser: `${parserUsed} fallback legacy label parser`,
+          totalBlocks: legacy.staged.length,
+          stagedCount: legacy.staged.length,
+          unmatchedCount: legacy.staged.length,
+          first5Jobs: legacy.staged.slice(0, 5).map(log => log.source_job_name || '(no job name)'),
+          first3UnmatchedJobs: legacy.staged.slice(0, 3).map(log => log.source_job_name || '(no job name)'),
+        },
+      };
+    }
+  }
+
+  const blocks = starts.map((start, index) => ({
+    sourceRow: index + 1,
+    lines: nonEmptyLines.slice(start, starts[index + 1] ?? nonEmptyLines.length),
+  }));
+
+  const getValueAfterLabel = (lines, label) => {
+    const index = lines.findIndex(line => isLabelLine(line, label));
+    if (index < 0) return '';
+    const valueIndex = nextNonEmptyIndex(lines, index + 1);
+    return valueIndex >= 0 ? lines[valueIndex] : '';
+  };
+
+  const collectAfterLabel = (lines, label, stopLabels) => {
+    const index = lines.findIndex(line => isLabelLine(line, label));
+    if (index < 0) return '';
+    const collected = [];
+    for (let i = index + 1; i < lines.length; i++) {
+      if (stopLabels.some(stop => isLabelLine(lines[i], stop))) break;
+      collected.push(lines[i]);
+    }
+    return collected.join('\n').trim();
+  };
+
+  blocks.forEach((block) => {
+    const lines = block.lines;
+    const logDate = parseDateHeading(lines[0]);
+    const jobName = getValueAfterLabel(lines, 'Job:');
+    const title = getValueAfterLabel(lines, 'Title:');
+    const addedBy = getValueAfterLabel(lines, 'Added By:');
+    const logNotes = collectAfterLabel(lines, 'Log Notes:', ['Weather Conditions:', 'Attachments:']);
+    const weatherSummary = getValueAfterLabel(lines, 'Weather Conditions:');
+    const weatherTimestamp = lines.find(line => /^[a-z]{3},\s+[a-z]{3}\s+\d{1,2},\s+\d{4},\s+\d{1,2}:\d{2}\s+[ap]m$/i.test(line)) || null;
+    const temps = lines
+      .map(line => line.match(/(-?\d+(?:\.\d+)?)\s*°?\s*f\b/i))
+      .filter(Boolean)
+      .map(match => Number(match[1]));
+    const tempHigh = temps[0] ?? null;
+    const tempLow = temps[1] ?? null;
+    const wind = (lines.find(line => /^wind:/i.test(line)) || '').replace(/^wind:\s*/i, '').trim() || null;
+    const humidity = (lines.find(line => /^humidity:/i.test(line)) || '').replace(/^humidity:\s*/i, '').trim() || null;
+    const precipitation = (lines.find(line => /^total precip:/i.test(line)) || '').replace(/^total precip:\s*/i, '').trim() || null;
+    const attachmentCount = Number.parseInt(getValueAfterLabel(lines, 'Attachments:'), 10) || 0;
+
+    if (!logDate) {
+      errors.push(`Block ${block.sourceRow}: missing date - skipped`);
+      return;
+    }
+
+    staged.push({
+      import_batch_id: batchId,
+      source_file_name: fileName,
+      source_row: block.sourceRow,
+      raw_source_text: lines.join('\n').slice(0, 2000),
+      log_date: logDate,
+      source_job_name: jobName || '',
+      normalized_job_name: normalize(jobName || ''),
+      title: title || null,
+      added_by: addedBy || null,
+      log_notes: logNotes || null,
+      weather_summary: weatherSummary || null,
+      weather_timestamp: weatherTimestamp,
+      temp_high: tempHigh,
+      temp_low: tempLow,
+      wind,
+      humidity,
+      precipitation,
+      attachment_count: attachmentCount,
+      needs_attachment_review: attachmentCount > 0,
+      match_status: 'unmatched',
+      matched_job_id: null,
+      matched_staged_job_id: null,
+      warnings: safeJson([]),
+      errors: safeJson([]),
+      review_status: 'pending',
+    });
+  });
+
+  const diagnostics = {
+    ...buildDiagnostics(),
+    totalBlocks: blocks.length,
+  };
+
+  if (staged.length === 0) {
+    errors.push([
+      'Daily Logs parse produced zero logs.',
+      `parser used: ${parserUsed}`,
+      `detected date headings: ${detectedDateHeadings.join(' | ') || '(none)'}`,
+      `detected Job: labels count: ${jobLabelCount}`,
+      'first 40 lines:',
+      first40Lines || '(empty)',
+    ].join('\n'));
+  }
+
+  return { staged, errors, diagnostics };
 }

--- a/src/lib/jobHelpers.js
+++ b/src/lib/jobHelpers.js
@@ -158,6 +158,32 @@ export function findExistingBuildertrendImportedJob(stagedJob, liveJobs = []) {
   return null;
 }
 
+export function findBuildertrendImportedJobForLog(sourceJobName, liveJobs = []) {
+  const source = normalizeBuildertrendMatchValue(sourceJobName);
+  if (!source) return null;
+
+  const importedJobs = (liveJobs || []).filter(isBuildertrendImportedJob);
+  const sourceCompact = source.replace(/\s+/g, '');
+
+  return importedJobs.find((job) => {
+    const rawName = normalizeBuildertrendMatchValue(job.buildertrend_id || job.buildertrendId || job.raw_job_name);
+    const title = normalizeBuildertrendMatchValue(job.clean_job_name || job.title);
+    const address = normalizeAddressParts(job.address);
+    const fullAddress = normalizeAddressParts(job.address, job.city, job.state, job.zip);
+    const addressCompact = address.replace(/\s+/g, '');
+    const fullAddressCompact = fullAddress.replace(/\s+/g, '');
+
+    return (
+      rawName === source ||
+      title === source ||
+      address === source ||
+      fullAddress === source ||
+      Boolean(sourceCompact && addressCompact && (addressCompact.includes(sourceCompact) || sourceCompact.includes(addressCompact))) ||
+      Boolean(sourceCompact && fullAddressCompact && (fullAddressCompact.includes(sourceCompact) || sourceCompact.includes(fullAddressCompact)))
+    );
+  }) || null;
+}
+
 export function requiresJobSignatureWorkflow(job) {
   if (!job) return false;
   if (isBuildertrendImportedJob(job)) return false;

--- a/src/pages/BTImport.jsx
+++ b/src/pages/BTImport.jsx
@@ -27,7 +27,7 @@ import {
   matchLogsToJobs,
   matchEventsToJobs,
 } from '@/lib/btParsers';
-import { findExistingBuildertrendImportedJob } from '@/lib/jobHelpers';
+import { findBuildertrendImportedJobForLog, findExistingBuildertrendImportedJob } from '@/lib/jobHelpers';
 import {
   importApprovedJobs,
   importApprovedDailyLogs,
@@ -242,6 +242,36 @@ function markAlreadyImportedJobs(stagedJobs, liveJobs) {
   });
 }
 
+function matchDailyLogsToImportedJobs(stagedLogs, liveJobs) {
+  return stagedLogs.map((log) => {
+    const match = findBuildertrendImportedJobForLog(log.source_job_name, liveJobs);
+    if (!match) return log;
+    return {
+      ...log,
+      match_status: 'matched_live',
+      matched_job_id: match.id || null,
+    };
+  });
+}
+
+function buildDailyLogDiagnosticLines(diagnostics, logs) {
+  if (!diagnostics) return [];
+  const matchedCount = logs.filter(log => log.match_status === 'matched_live').length;
+  const unmatched = logs.filter(log => log.match_status === 'unmatched');
+  const attachmentReviewCount = logs.filter(log => log.needs_attachment_review).length;
+  return [
+    `[Daily Logs diagnostics]`,
+    `  parser used:              ${diagnostics.parser}`,
+    `  total log blocks found:   ${diagnostics.totalBlocks}`,
+    `  staged logs created:      ${logs.length}`,
+    `  matched logs:             ${matchedCount}`,
+    `  unmatched logs:           ${unmatched.length}`,
+    `  attachment review count:  ${attachmentReviewCount}`,
+    `  first 5 parsed jobs:      ${logs.slice(0, 5).map(log => log.source_job_name || '(no job name)').join(' | ') || '(none)'}`,
+    `  first 3 unmatched jobs:   ${unmatched.slice(0, 3).map(log => log.source_job_name || '(no job name)').join(' | ') || '(none)'}`,
+  ];
+}
+
 const STEPS = { UPLOAD: 'upload', DRY_RUN: 'dry_run', CONFIRM: 'confirm', DONE: 'done' };
 
 export default function BTImport() {
@@ -311,13 +341,14 @@ export default function BTImport() {
 
       const allErrors = [];
       let jobs = [], logs = [], events = [];
+      let liveJobsForMatching = null;
 
       // Parse Jobsites CSV — RFC4180 state-machine, no AI extraction
       if (files.jobsites) {
         const { rows, debugInfo } = await parseJobsitesCsv(files.jobsites);
         const result = parseJobsiteRows(rows, batch.id, files.jobsites.name);
-        const liveJobs = await base44.entities.Job.list('-created_date');
-        jobs = markAlreadyImportedJobs(result.staged, liveJobs);
+        liveJobsForMatching = liveJobsForMatching || await base44.entities.Job.list('-created_date');
+        jobs = markAlreadyImportedJobs(result.staged, liveJobsForMatching);
         allErrors.push(...result.errors.map(e => `[Jobs] ${e}`));
 
         // ── Parser diagnostics summary (always shown) ─────────────────────────
@@ -345,10 +376,15 @@ export default function BTImport() {
 
       // Parse Daily Logs (no matching yet — staged job IDs not known until after DB insert)
       if (files.daily_logs) {
-        const text = await readFileAsText(files.daily_logs);
+        const text = await files.daily_logs.text();
         const result = parseDailyLogText(text, batch.id, files.daily_logs.name);
-        logs = result.staged;
+        liveJobsForMatching = liveJobsForMatching || await base44.entities.Job.list('-created_date');
+        logs = matchDailyLogsToImportedJobs(result.staged, liveJobsForMatching);
+        allErrors.push(...buildDailyLogDiagnosticLines(result.diagnostics, logs));
         allErrors.push(...result.errors.map(e => `[Logs] ${e}`));
+        if (logs.length === 0) {
+          throw new Error(result.errors.join('\n\n') || 'Daily Logs parse produced zero logs.');
+        }
       }
 
       // Parse Calendar (same — match after DB insert)
@@ -487,6 +523,7 @@ export default function BTImport() {
     approvedJobs:   stagedJobs.filter(j => j.review_status === 'approved').length,
     skippedJobs:    stagedJobs.filter(j => j.review_status === 'skipped').length,
     totalLogs:      stagedLogs.length,
+    matchedLogs:    stagedLogs.filter(l => l.match_status === 'matched_live' || l.match_status === 'matched_staged').length,
     unmatchedLogs:  stagedLogs.filter(l => l.match_status === 'unmatched').length,
     attachmentLogs: stagedLogs.filter(l => l.needs_attachment_review).length,
     totalEvents:    stagedEvents.length,


### PR DESCRIPTION
## Summary
- Adds direct `.txt` parsing for Buildertrend Daily Logs copied from printout / Google Docs.
- Parses date-heading log blocks and extracts job, title, added by, notes, weather, timestamp, temps, wind, humidity, precipitation, attachments, and raw source text.
- Stages unmatched logs instead of discarding them.
- Adds diagnostics for dry-run review.
- Keeps dry-run separate from live import.

## Validation
- npm run lint
- npm run build

## Safety
- Does not touch Cloudflare Worker code.
- Does not touch R2 settings.
- Does not delete records.
- Does not perform live import automatically.