### PR TITLE
Add Buildertrend calendar PDF dry-run parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "moment": "^2.30.1",
         "next-themes": "^0.4.4",
         "pdf-lib": "^1.17.1",
+        "pdfjs-dist": "^5.7.284",
         "react": "^18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.2.0",
@@ -1176,6 +1177,271 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7814,6 +8080,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.7.284",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
+      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.100"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "moment": "^2.30.1",
     "next-themes": "^0.4.4",
     "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^5.7.284",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.2.0",

--- a/src/components/btimport/BTImportUploader.jsx
+++ b/src/components/btimport/BTImportUploader.jsx
@@ -3,9 +3,9 @@ import { Button } from '@/components/ui/button';
 import { Upload, X, FileText, CheckCircle2 } from 'lucide-react';
 
 const FILE_TYPES = [
-  { key: 'jobsites',         label: 'Jobsites Export',      accept: '.xlsx,.xls,.csv', hint: 'Excel/CSV export from BT → Jobs list' },
-  { key: 'daily_logs',       label: 'Daily Logs Export',    accept: '.txt,.csv',       hint: 'Text export from BT → Daily Logs' },
-  { key: 'schedule_calendar',label: 'Schedule / Calendar',  accept: '.txt,.csv',       hint: 'Text export from BT → Schedule' },
+  { key: 'jobsites',          label: 'Jobsites Export',     accept: '.xlsx,.xls,.csv', hint: 'Excel/CSV export from BT - Jobs list' },
+  { key: 'daily_logs',        label: 'Daily Logs Export',   accept: '.txt,.csv',       hint: 'Text export from BT - Daily Logs' },
+  { key: 'schedule_calendar', label: 'Schedule / Calendar', accept: '.pdf,.txt,.csv',  hint: 'PDF or text export from BT - Schedule' },
 ];
 
 export default function BTImportUploader({ onFilesReady, loading }) {
@@ -17,7 +17,11 @@ export default function BTImportUploader({ onFilesReady, loading }) {
   };
 
   const removeFile = (key) => {
-    setFiles(prev => { const n = { ...prev }; delete n[key]; return n; });
+    setFiles(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
   };
 
   const canSubmit = Object.keys(files).length > 0 && !loading;
@@ -62,7 +66,7 @@ export default function BTImportUploader({ onFilesReady, loading }) {
         className="w-full h-11 gap-2"
       >
         <Upload className="w-4 h-4" />
-        {loading ? 'Parsing…' : `Parse & Stage ${Object.keys(files).length} file${Object.keys(files).length !== 1 ? 's' : ''}`}
+        {loading ? 'Parsing...' : `Parse & Stage ${Object.keys(files).length} file${Object.keys(files).length !== 1 ? 's' : ''}`}
       </Button>
     </div>
   );

--- a/src/components/btimport/BTStagedEventsTable.jsx
+++ b/src/components/btimport/BTStagedEventsTable.jsx
@@ -1,20 +1,24 @@
 import React, { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
-import { ChevronDown, ChevronRight, CheckCircle2, XCircle } from 'lucide-react';
+import { ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, Copy } from 'lucide-react';
+
+function safeJson(str) {
+  try { return JSON.parse(str || '[]'); } catch { return []; }
+}
 
 const STATUS_BADGE = {
-  pending:     { label: 'Pending',  className: 'bg-muted text-muted-foreground' },
-  approved:    { label: 'Approved', className: 'bg-green-100 text-green-700' },
-  skipped:     { label: 'Skipped', className: 'bg-secondary text-secondary-foreground' },
-  needs_review:{ label: 'Needs Review', className: 'bg-amber-100 text-amber-700' },
+  pending:      { label: 'Pending',      className: 'bg-muted text-muted-foreground' },
+  approved:     { label: 'Approved',     className: 'bg-green-100 text-green-700' },
+  skipped:      { label: 'Skipped',      className: 'bg-secondary text-secondary-foreground' },
+  needs_review: { label: 'Needs Review', className: 'bg-amber-100 text-amber-700' },
 };
 
 const MATCH_BADGE = {
-  matched_staged:  { label: 'Matched Staged', className: 'bg-primary/10 text-primary' },
-  matched_live:    { label: 'Matched Live',   className: 'bg-green-100 text-green-700' },
-  unmatched:       { label: 'Unmatched',      className: 'bg-amber-100 text-amber-700' },
-  office_unmapped: { label: 'Office/Internal',className: 'bg-secondary text-secondary-foreground' },
-  needs_review:    { label: 'Needs Review',   className: 'bg-amber-100 text-amber-700' },
+  matched_staged: { label: 'Matched Staged',  className: 'bg-primary/10 text-primary' },
+  matched_live:   { label: 'Matched Live',    className: 'bg-green-100 text-green-700' },
+  unmatched:      { label: 'Unmatched',       className: 'bg-amber-100 text-amber-700' },
+  office_unmapped:{ label: 'Office/Internal', className: 'bg-secondary text-secondary-foreground' },
+  needs_review:   { label: 'Needs Review',    className: 'bg-amber-100 text-amber-700' },
 };
 
 export default function BTStagedEventsTable({ events, onStatusChange }) {
@@ -34,8 +38,9 @@ export default function BTStagedEventsTable({ events, onStatusChange }) {
       </div>
       {events.map(ev => {
         const isOpen = expanded === ev.id;
+        const warnings = safeJson(ev.warnings);
         const statusBadge = STATUS_BADGE[ev.review_status] || STATUS_BADGE.pending;
-        const matchBadge  = ev.is_office_event
+        const matchBadge = ev.is_office_event
           ? MATCH_BADGE.office_unmapped
           : (MATCH_BADGE[ev.match_status] || MATCH_BADGE.unmatched);
 
@@ -51,8 +56,13 @@ export default function BTStagedEventsTable({ events, onStatusChange }) {
                   <p className="text-sm font-medium text-foreground truncate">{ev.event_title}</p>
                   <p className="text-xs text-muted-foreground">
                     {ev.event_date}
-                    {ev.start_time && ` · ${ev.start_time}${ev.end_time ? `–${ev.end_time}` : ''}`}
-                    {ev.source_job_name && ` · ${ev.source_job_name}`}
+                    {ev.start_time && ` - ${ev.start_time}${ev.end_time ? `-${ev.end_time}` : ''}`}
+                    {ev.source_job_name && ` - ${ev.source_job_name}`}
+                    {ev.duplicate_hash && (
+                      <span className="ml-1 inline-flex items-center gap-0.5 text-muted-foreground">
+                        <Copy className="w-2.5 h-2.5" /> deduped
+                      </span>
+                    )}
                   </p>
                 </div>
               </div>
@@ -82,6 +92,27 @@ export default function BTStagedEventsTable({ events, onStatusChange }) {
                 <p>Non-production: <span className="text-foreground">{ev.is_non_production ? 'Yes' : 'No'}</span></p>
                 <p>Office event: <span className="text-foreground">{ev.is_office_event ? 'Yes' : 'No'}</span></p>
                 <p>Source row: <span className="text-foreground">{ev.source_row}</span></p>
+                {ev.source_page && <p>Source page: <span className="text-foreground">{ev.source_page}</span></p>}
+                {warnings.length > 0 && (
+                  <div className="flex gap-1 flex-wrap pt-1">
+                    {warnings.map((warning, i) => (
+                      <span key={i} className="inline-flex items-center gap-1 text-[10px] bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full">
+                        <AlertTriangle className="w-2.5 h-2.5" /> {warning}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {ev.raw_source_text && (
+                  <details className="pt-1">
+                    <summary className="text-[10px] text-muted-foreground cursor-pointer hover:text-foreground select-none">Raw source text</summary>
+                    <pre
+                      className="mt-1 text-[10px] text-muted-foreground bg-muted/40 rounded p-2 whitespace-pre-wrap break-all max-h-32 overflow-y-auto"
+                      style={{ userSelect: 'text', WebkitUserSelect: 'text', cursor: 'text' }}
+                    >
+                      {ev.raw_source_text}
+                    </pre>
+                  </details>
+                )}
               </div>
             )}
           </div>

--- a/src/lib/btParsers.js
+++ b/src/lib/btParsers.js
@@ -84,6 +84,17 @@ function stripDatePrefix(name) {
   return { clean: name.trim(), date: null };
 }
 
+function normalizeJobNameForMatch(name) {
+  return normalize(stripDatePrefix(name || '').clean || name || '');
+}
+
+function normalizeHashValue(value) {
+  return normalizeJobNameForMatch(value)
+    .replace(/[^\w\s#-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // ─── Jobsite Rows (Excel) ──────────────────────────────────────────────────────
 
 /**
@@ -171,7 +182,7 @@ export function parseJobsiteRows(rows, batchId, fileName) {
     }
 
     const { clean: cleanName, date: receivedDate } = stripDatePrefix(rawName);
-    const normalizedName = normalize(cleanName || rawName);
+    const normalizedName = normalizeJobNameForMatch(rawName);
 
     const warnings = [];
     const flags = [];
@@ -308,7 +319,7 @@ function parseDailyLogTextLegacy(text, batchId, fileName) {
       raw_source_text: block.slice(0, 2000),
       log_date: logDate,
       source_job_name: jobName || '',
-      normalized_job_name: normalize(jobName || ''),
+      normalized_job_name: normalizeJobNameForMatch(jobName || ''),
       title: title || null,
       added_by: addedBy || null,
       log_notes: logNotes || null,
@@ -336,6 +347,331 @@ function parseDailyLogTextLegacy(text, batchId, fileName) {
 
 const NON_PRODUCTION_KEYWORDS = /\b(estimate|tour|birthday|reminder|meeting|office|holiday|closed|vacation|training)\b/i;
 const OFFICE_KEYWORDS = /grand strand office|gs office|office only/i;
+const PRODUCTION_KEYWORDS = /\b(drywall|paint|painting|patch|skim|install|repair|trim|texture|caulk|carpentry|framing|siding|ceiling|punch|warranty|touch\s*up)\b/i;
+const TIME_RE = /\b\d{1,2}:\d{2}\s*[AP]M\b/gi;
+
+function classifyCalendarEvent(eventTitle, sourceJobName) {
+  const combined = `${eventTitle || ''} ${sourceJobName || ''}`;
+  const isOffice = OFFICE_KEYWORDS.test(combined) || NON_PRODUCTION_KEYWORDS.test(combined) || !sourceJobName;
+
+  let eventCategory = 'other';
+  if (/estimate/i.test(combined)) eventCategory = 'estimate';
+  else if (/tour/i.test(combined)) eventCategory = 'tour';
+  else if (/meeting/i.test(combined)) eventCategory = 'meeting';
+  else if (/reminder/i.test(combined)) eventCategory = 'reminder';
+  else if (isOffice) eventCategory = 'office_internal';
+  else if (PRODUCTION_KEYWORDS.test(combined) || sourceJobName) eventCategory = 'job_visit';
+
+  return {
+    eventCategory,
+    isNonProduction: isOffice && !PRODUCTION_KEYWORDS.test(combined),
+    isOffice,
+  };
+}
+
+function createCalendarDuplicateHash({ eventTitle, eventDate, startTime, endTime, sourceJobName }) {
+  return [
+    eventDate || '',
+    startTime || '',
+    endTime || '',
+    normalizeHashValue(eventTitle),
+    normalizeHashValue(sourceJobName),
+  ].join('|');
+}
+
+function cleanCalendarText(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+-\s*$/, '')
+    .replace(/-\s*$/, '')
+    .trim();
+}
+
+function normalizePdfItems(items) {
+  return (items || [])
+    .map(item => ({
+      ...item,
+      str: String(item.str || '').trim(),
+      x: Number(item.x || 0),
+      y: Number(item.y || 0),
+      page: Number(item.page || 1),
+    }))
+    .filter(item => item.str);
+}
+
+function detectCalendarMonthYear(pages) {
+  const monthNames = Object.keys(MONTHS).filter(name => name.length > 3 || name === 'may');
+  const allText = pages.flatMap(page => page.items.map(item => item.str));
+  const monthLabel = allText.find(text => monthNames.some(month => month.toLowerCase() === text.toLowerCase()));
+  const month = monthLabel ? Number(MONTHS[monthLabel.toLowerCase()]) : null;
+  const yearMatch = allText.join(' ').match(/\b(20\d{2})\s+\d{1,2}\/\d{1,2}\b/) || allText.join(' ').match(/\b(20\d{2})\b/);
+  const year = yearMatch ? Number(yearMatch[1]) : null;
+  return { month, year, label: monthLabel || '' };
+}
+
+function findDayMarkerRows(items) {
+  const candidates = items
+    .filter(item => /^\d{1,2}$/.test(item.str) && Number(item.str) >= 1 && Number(item.str) <= 31)
+    .filter(item => item.x >= 35 && item.x <= 740);
+
+  const byY = new Map();
+  candidates.forEach(item => {
+    const yKey = Math.round(item.y / 4) * 4;
+    if (!byY.has(yKey)) byY.set(yKey, []);
+    byY.get(yKey).push(item);
+  });
+
+  return [...byY.entries()]
+    .map(([y, rowItems]) => ({
+      y: Number(y),
+      items: rowItems.sort((a, b) => a.x - b.x).slice(0, 7),
+    }))
+    .filter(row => row.items.length >= 7)
+    .sort((a, b) => b.y - a.y);
+}
+
+function assignDatesToRows(rows, month, year) {
+  if (!month || !year) return rows;
+  let cursorMonth = rows[0]?.items?.[0] && Number(rows[0].items[0].str) > 7 ? month - 1 : month;
+  let cursorYear = year;
+  if (cursorMonth === 0) {
+    cursorMonth = 12;
+    cursorYear -= 1;
+  }
+  let previousDay = null;
+
+  return rows.map(row => ({
+    ...row,
+    dates: row.items.map(item => {
+      const day = Number(item.str);
+      if (previousDay != null && day < previousDay) {
+        cursorMonth += 1;
+        if (cursorMonth === 13) {
+          cursorMonth = 1;
+          cursorYear += 1;
+        }
+      }
+      previousDay = day;
+      return `${cursorYear}-${String(cursorMonth).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }),
+  }));
+}
+
+function getColumnIndex(item, row) {
+  const centers = row.items.map(marker => marker.x);
+  let bestIndex = 0;
+  let bestDistance = Infinity;
+  centers.forEach((center, index) => {
+    const distance = Math.abs(item.x - center);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  });
+  return bestIndex;
+}
+
+function groupCellLines(items) {
+  const seen = new Set();
+  const uniqueItems = [];
+  items.forEach(item => {
+    const key = `${Math.round(item.x)}|${Math.round(item.y)}|${item.str}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    uniqueItems.push(item);
+  });
+
+  const rows = [];
+  uniqueItems.sort((a, b) => b.y - a.y || a.x - b.x).forEach(item => {
+    const row = rows.find(existing => Math.abs(existing.y - item.y) <= 4);
+    if (row) row.items.push(item);
+    else rows.push({ y: item.y, items: [item] });
+  });
+
+  return rows
+    .sort((a, b) => b.y - a.y)
+    .map(row => row.items.sort((a, b) => a.x - b.x).map(item => item.str).join(' ').trim())
+    .filter(line => line && !/^non-workday$/i.test(line) && !/^(sunday|monday|tuesday|wednesday|thursday|friday|saturday)$/i.test(line));
+}
+
+function splitCalendarEventBlocks(lines) {
+  const raw = lines.join('\n');
+  const parenMatches = [...raw.matchAll(/\([^)]{2,200}\)/g)];
+  if (parenMatches.length) {
+    return parenMatches.map((match, index) => {
+      const previousEnd = index > 0 ? parenMatches[index - 1].index + parenMatches[index - 1][0].length : 0;
+      const nextStart = parenMatches[index + 1]?.index ?? raw.length;
+      return raw.slice(previousEnd, nextStart).split('\n').map(line => line.trim()).filter(Boolean);
+    });
+  }
+
+  const blocks = [];
+  let current = [];
+  let timeCount = 0;
+
+  lines.forEach(line => {
+    current.push(line);
+    timeCount += (line.match(TIME_RE) || []).length;
+    if (timeCount >= 2) {
+      blocks.push(current);
+      current = [];
+      timeCount = 0;
+    }
+  });
+
+  if (current.some(line => /\([^)]*/.test(line))) blocks.push(current);
+  return blocks;
+}
+
+function parseCalendarEventBlock(blockLines) {
+  const raw = blockLines.join('\n').trim();
+  const times = [...raw.matchAll(TIME_RE)].map(match => match[0].replace(/\s+/g, ' ').toUpperCase());
+  const withoutTimes = raw.replace(TIME_RE, ' ');
+  const jobMatch = withoutTimes.match(/\(([\s\S]*?)\)/);
+  const sourceJobName = cleanCalendarText(jobMatch?.[1] || '');
+  let beforeJob = jobMatch ? withoutTimes.slice(0, jobMatch.index) : withoutTimes;
+  if (beforeJob.includes(')')) beforeJob = beforeJob.slice(beforeJob.lastIndexOf(')') + 1);
+  const eventTitle = cleanCalendarText(beforeJob) || sourceJobName || 'Untitled calendar event';
+
+  if (!eventTitle && !sourceJobName) return null;
+
+  return {
+    raw,
+    eventTitle,
+    sourceJobName,
+    startTime: times[0] || null,
+    endTime: times[1] || null,
+  };
+}
+
+export function parseCalendarPdfPages(pages, batchId, fileName) {
+  const staged = [];
+  const errors = [];
+  const malformedBlocks = [];
+  const duplicateHashes = new Set();
+  let rawBlockCount = 0;
+  let duplicateSkipped = 0;
+
+  const normalizedPages = (pages || []).map(page => ({
+    page: page.page,
+    items: normalizePdfItems(page.items),
+  }));
+  const { month, year, label } = detectCalendarMonthYear(normalizedPages);
+
+  if (!month || !year) {
+    errors.push('Calendar PDF parser could not detect month/year from the text layer.');
+    return { staged, errors, diagnostics: { parser: 'Buildertrend Calendar PDF text-layer parser', totalRawBlocks: 0, deduplicatedEvents: 0, duplicateSkipped: 0, malformedBlocks: 0, first10Events: [] } };
+  }
+
+  const rowRefs = [];
+  normalizedPages.forEach(page => {
+    findDayMarkerRows(page.items).forEach(row => rowRefs.push({ ...row, page: page.page }));
+  });
+  const rowsWithDates = assignDatesToRows(rowRefs, month, year);
+  const rowsByPage = new Map();
+  rowsWithDates.forEach(row => {
+    if (!rowsByPage.has(row.page)) rowsByPage.set(row.page, []);
+    rowsByPage.get(row.page).push(row);
+  });
+
+  let carryRow = null;
+  normalizedPages.forEach(page => {
+    const rows = (rowsByPage.get(page.page) || []).sort((a, b) => b.y - a.y);
+    const segments = [];
+    if (carryRow && rows[0]) segments.push({ row: carryRow, top: Infinity, bottom: rows[0].y + 4 });
+    rows.forEach((row, index) => {
+      segments.push({
+        row,
+        top: row.y - 5,
+        bottom: rows[index + 1] ? rows[index + 1].y + 4 : -Infinity,
+      });
+    });
+
+    segments.forEach(segment => {
+      const cellItems = Array.from({ length: 7 }, () => []);
+      page.items.forEach(item => {
+        if (item.y > segment.top || item.y <= segment.bottom) return;
+        if (/^\d{1,2}$/.test(item.str) && Math.abs(item.y - segment.row.y) <= 6) return;
+        const col = getColumnIndex(item, segment.row);
+        cellItems[col].push(item);
+      });
+
+      cellItems.forEach((items, colIndex) => {
+        const eventDate = segment.row.dates?.[colIndex];
+        if (!eventDate || items.length === 0) return;
+        const lines = groupCellLines(items);
+        splitCalendarEventBlocks(lines).forEach(blockLines => {
+          rawBlockCount++;
+          const parsed = parseCalendarEventBlock(blockLines);
+          if (!parsed || !parsed.sourceJobName) {
+            malformedBlocks.push(blockLines.join(' | ').slice(0, 250));
+            return;
+          }
+
+          const duplicateHash = createCalendarDuplicateHash({
+            eventTitle: parsed.eventTitle,
+            eventDate,
+            startTime: parsed.startTime,
+            endTime: parsed.endTime,
+            sourceJobName: parsed.sourceJobName,
+          });
+          if (duplicateHashes.has(duplicateHash)) {
+            duplicateSkipped++;
+            return;
+          }
+          duplicateHashes.add(duplicateHash);
+
+          const classification = classifyCalendarEvent(parsed.eventTitle, parsed.sourceJobName);
+          const warnings = [];
+          if (classification.isOffice) warnings.push('Office/internal calendar item - requires review');
+
+          staged.push({
+            import_batch_id: batchId,
+            source_file_name: fileName,
+            source_row: rawBlockCount,
+            source_page: page.page,
+            raw_source_text: parsed.raw.slice(0, 2000),
+            event_date: eventDate,
+            event_title: parsed.eventTitle,
+            start_time: parsed.startTime,
+            end_time: parsed.endTime,
+            source_job_name: parsed.sourceJobName,
+            normalized_job_name: normalizeJobNameForMatch(parsed.sourceJobName),
+            duplicate_hash: duplicateHash,
+            event_category: classification.eventCategory,
+            is_non_production: classification.isNonProduction,
+            is_office_event: classification.isOffice,
+            match_status: 'unmatched',
+            matched_job_id: null,
+            matched_staged_job_id: null,
+            warnings: safeJson(warnings),
+            errors: safeJson([]),
+            review_status: classification.isOffice ? 'needs_review' : 'pending',
+          });
+        });
+      });
+    });
+
+    carryRow = rows[rows.length - 1] || carryRow;
+  });
+
+  const diagnostics = {
+    parser: 'Buildertrend Calendar PDF text-layer parser',
+    month: label,
+    year,
+    totalRawBlocks: rawBlockCount,
+    deduplicatedEvents: staged.length,
+    duplicateSkipped,
+    malformedBlocks: malformedBlocks.length,
+    first10Events: staged.slice(0, 10).map(event => `${event.event_date} ${event.start_time || ''}-${event.end_time || ''} ${event.event_title} (${event.source_job_name})`.trim()),
+  };
+
+  if (staged.length === 0) {
+    errors.push('Calendar PDF parser produced zero staged events from the text layer.');
+  }
+
+  return { staged, errors, diagnostics };
+}
 
 /**
  * Parse a plain-text Buildertrend schedule/calendar export.
@@ -411,7 +747,7 @@ export function parseCalendarText(text, batchId, fileName) {
       start_time: startTime,
       end_time: endTime,
       source_job_name: sourceJobName,
-      normalized_job_name: normalize(sourceJobName),
+      normalized_job_name: normalizeJobNameForMatch(sourceJobName),
       event_category: eventCategory,
       is_non_production: isNonProd,
       is_office_event: isOffice,
@@ -467,6 +803,7 @@ export function matchEventsToJobs(stagedEvents, stagedJobs) {
       return {
         ...ev,
         match_status: 'matched_staged',
+        matched_staged_job_id: match.id || null,
       };
     }
     return ev;
@@ -584,7 +921,7 @@ export function parseDailyLogText(text, batchId, fileName) {
       raw_source_text: lines.join('\n').slice(0, 2000),
       log_date: logDate,
       source_job_name: jobName || '',
-      normalized_job_name: normalize(jobName || ''),
+      normalized_job_name: normalizeJobNameForMatch(jobName || ''),
       title: title || null,
       added_by: addedBy || null,
       log_notes: logNotes || null,

--- a/src/lib/btPdfText.js
+++ b/src/lib/btPdfText.js
@@ -1,0 +1,30 @@
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+
+export async function extractPdfTextPages(file) {
+  const data = new Uint8Array(await file.arrayBuffer());
+  const pdf = await pdfjsLib.getDocument({ data, disableWorker: true }).promise;
+  const pages = [];
+
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+    const page = await pdf.getPage(pageNumber);
+    const content = await page.getTextContent({ includeMarkedContent: false });
+    const items = content.items
+      .map((item) => ({
+        str: String(item.str || '').trim(),
+        x: item.transform?.[4] || 0,
+        y: item.transform?.[5] || 0,
+        width: item.width || 0,
+        page: pageNumber,
+      }))
+      .filter(item => item.str);
+
+    pages.push({ page: pageNumber, items });
+  }
+
+  const totalItems = pages.reduce((sum, page) => sum + page.items.length, 0);
+  if (totalItems === 0) {
+    throw new Error('Calendar PDF text extraction returned no text. OCR is not enabled for this dry-run parser.');
+  }
+
+  return pages;
+}

--- a/src/lib/jobHelpers.js
+++ b/src/lib/jobHelpers.js
@@ -94,6 +94,13 @@ export function normalizeBuildertrendMatchValue(value) {
     .trim();
 }
 
+export function stripBuildertrendDatePrefix(value) {
+  return String(value || '')
+    .replace(/^\d{4}\s+\d{1,2}\/\d{1,2}\s+/, '')
+    .replace(/^\d{1,2}[/-]\d{1,2}[/-]\d{4}\s+/, '')
+    .trim();
+}
+
 function normalizeAddressParts(...parts) {
   return normalizeBuildertrendMatchValue(parts.filter(Boolean).join(' '));
 }
@@ -159,7 +166,7 @@ export function findExistingBuildertrendImportedJob(stagedJob, liveJobs = []) {
 }
 
 export function findBuildertrendImportedJobForLog(sourceJobName, liveJobs = []) {
-  const source = normalizeBuildertrendMatchValue(sourceJobName);
+  const source = normalizeBuildertrendMatchValue(stripBuildertrendDatePrefix(sourceJobName));
   if (!source) return null;
 
   const importedJobs = (liveJobs || []).filter(isBuildertrendImportedJob);

--- a/src/pages/BTImport.jsx
+++ b/src/pages/BTImport.jsx
@@ -24,10 +24,12 @@ import {
   parseJobsiteRows,
   parseDailyLogText,
   parseCalendarText,
+  parseCalendarPdfPages,
   matchLogsToJobs,
   matchEventsToJobs,
 } from '@/lib/btParsers';
 import { findBuildertrendImportedJobForLog, findExistingBuildertrendImportedJob } from '@/lib/jobHelpers';
+import { extractPdfTextPages } from '@/lib/btPdfText';
 import {
   importApprovedJobs,
   importApprovedDailyLogs,
@@ -37,6 +39,50 @@ import {
 import { toast } from 'sonner';
 
 // ─── File reading helpers ─────────────────────────────────────────────────────
+
+const RATE_LIMIT_ERROR_MESSAGE = 'Base44 rate limit reached. Please wait a moment and retry.';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRateLimitError(error) {
+  const status = error?.status || error?.response?.status || error?.code;
+  const message = String(error?.message || error?.error || '').toLowerCase();
+  return status === 429 || message.includes('rate limit') || message.includes('too many requests');
+}
+
+async function withRateLimitRetry(fn, { retries = 3, baseDelayMs = 750, onRetry } = {}) {
+  let attempt = 0;
+  while (attempt <= retries) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isRateLimitError(error) || attempt === retries) throw error;
+      const delayMs = baseDelayMs * (2 ** attempt);
+      if (onRetry) onRetry({ attempt: attempt + 1, retries, delayMs, error });
+      await sleep(delayMs);
+      attempt++;
+    }
+  }
+}
+
+async function runThrottled(items, worker, {
+  batchSize = 25,
+  delayMs = 500,
+  retries = 3,
+  onProgress,
+  onRetry,
+} = {}) {
+  const total = items.length;
+  for (let index = 0; index < total; index += batchSize) {
+    const chunk = items.slice(index, index + batchSize);
+    if (onProgress) onProgress({ completed: index, total, batchSize: chunk.length });
+    await withRateLimitRetry(() => worker(chunk, index, total), { retries, baseDelayMs: delayMs, onRetry });
+    if (index + batchSize < total) await sleep(delayMs);
+  }
+  if (onProgress) onProgress({ completed: total, total, batchSize: 0 });
+}
 
 async function readFileAsText(file) {
   return new Promise((resolve, reject) => {
@@ -254,6 +300,19 @@ function matchDailyLogsToImportedJobs(stagedLogs, liveJobs) {
   });
 }
 
+function matchCalendarEventsToImportedJobs(stagedEvents, liveJobs) {
+  return stagedEvents.map((event) => {
+    if (event.is_office_event) return event;
+    const match = findBuildertrendImportedJobForLog(event.source_job_name, liveJobs);
+    if (!match) return event;
+    return {
+      ...event,
+      match_status: 'matched_live',
+      matched_job_id: match.id || null,
+    };
+  });
+}
+
 function buildDailyLogDiagnosticLines(diagnostics, logs) {
   if (!diagnostics) return [];
   const matchedCount = logs.filter(log => log.match_status === 'matched_live').length;
@@ -272,6 +331,26 @@ function buildDailyLogDiagnosticLines(diagnostics, logs) {
   ];
 }
 
+function buildCalendarDiagnosticLines(diagnostics, events) {
+  if (!diagnostics) return [];
+  const matchedCount = events.filter(event => event.match_status === 'matched_live' || event.match_status === 'matched_staged').length;
+  const unmatched = events.filter(event => event.match_status === 'unmatched' && !event.is_office_event);
+  const officeCount = events.filter(event => event.is_office_event).length;
+  return [
+    `[Calendar PDF diagnostics]`,
+    `  parser used:              ${diagnostics.parser}`,
+    `  calendar month/year:      ${[diagnostics.month, diagnostics.year].filter(Boolean).join(' ') || '(unknown)'}`,
+    `  total raw blocks found:   ${diagnostics.totalRawBlocks}`,
+    `  deduplicated events:      ${diagnostics.deduplicatedEvents}`,
+    `  duplicate blocks skipped: ${diagnostics.duplicateSkipped}`,
+    `  matched jobs:             ${matchedCount}`,
+    `  unmatched jobs:           ${unmatched.length}`,
+    `  office/internal review:   ${officeCount}`,
+    `  malformed blocks:         ${diagnostics.malformedBlocks}`,
+    `  first 10 parsed events:   ${diagnostics.first10Events?.join(' | ') || '(none)'}`,
+  ];
+}
+
 const STEPS = { UPLOAD: 'upload', DRY_RUN: 'dry_run', CONFIRM: 'confirm', DONE: 'done' };
 
 export default function BTImport() {
@@ -282,6 +361,7 @@ export default function BTImport() {
   const [step, setStep]         = useState(STEPS.UPLOAD);
   const [parsing, setParsing]   = useState(false);
   const [importing, setImporting] = useState(false);
+  const [progressMessage, setProgressMessage] = useState('');
   const [parseError, setParseError] = useState('');
   const [currentBatchId, setCurrentBatchId] = useState(null);
 
@@ -318,6 +398,7 @@ export default function BTImport() {
     setParsing(true);
     setParseError('');
     setParseErrors([]);
+    setProgressMessage('');
     setStagedJobs([]);
     setStagedLogs([]);
     setStagedEvents([]);
@@ -328,7 +409,7 @@ export default function BTImport() {
       const fileNames = Object.entries(files).map(([type, f]) => `${type}:${f.name}`).join(', ');
       const sourceType = Object.keys(files).length === 1 ? Object.keys(files)[0] : 'mixed';
 
-      const batch = await base44.entities.ImportBatch.create({
+      const batch = await withRateLimitRetry(() => base44.entities.ImportBatch.create({
         source_system: 'buildertrend',
         source_type: sourceType,
         source_file_name: fileNames,
@@ -336,6 +417,8 @@ export default function BTImport() {
         uploaded_at: new Date().toISOString(),
         dry_run_status: 'running',
         import_status: 'not_started',
+      }), {
+        onRetry: () => setProgressMessage('Creating import batch after Base44 rate limit...'),
       });
       setCurrentBatchId(batch.id);
 
@@ -389,16 +472,44 @@ export default function BTImport() {
 
       // Parse Calendar (same — match after DB insert)
       if (files.schedule_calendar) {
-        const text = await readFileAsText(files.schedule_calendar);
-        const result = parseCalendarText(text, batch.id, files.schedule_calendar.name);
-        events = result.staged;
+        const isPdf = files.schedule_calendar.type === 'application/pdf' || /\.pdf$/i.test(files.schedule_calendar.name);
+        const result = isPdf
+          ? parseCalendarPdfPages(await extractPdfTextPages(files.schedule_calendar), batch.id, files.schedule_calendar.name)
+          : parseCalendarText(await readFileAsText(files.schedule_calendar), batch.id, files.schedule_calendar.name);
+        liveJobsForMatching = liveJobsForMatching || await base44.entities.Job.list('-created_date');
+        events = matchCalendarEventsToImportedJobs(result.staged, liveJobsForMatching);
+        if (isPdf) allErrors.push(...buildCalendarDiagnosticLines(result.diagnostics, events));
         allErrors.push(...result.errors.map(e => `[Calendar] ${e}`));
       }
 
       // Persist staged records to DB
-      if (jobs.length)   await base44.entities.StagedJob.bulkCreate(jobs);
-      if (logs.length)   await base44.entities.StagedDailyLog.bulkCreate(logs);
-      if (events.length) await base44.entities.StagedCalendarEvent.bulkCreate(events);
+      if (jobs.length) {
+        setProgressMessage(`Staging Jobs 0/${jobs.length}`);
+        await runThrottled(jobs, async (chunk) => {
+          await base44.entities.StagedJob.bulkCreate(chunk);
+        }, {
+          onProgress: ({ completed, total, batchSize }) => setProgressMessage(`Staging Jobs ${Math.min(completed + batchSize, total)}/${total}`),
+          onRetry: ({ delayMs }) => setProgressMessage(`Staging Jobs hit a Base44 rate limit. Retrying in ${Math.round(delayMs / 1000)}s...`),
+        });
+      }
+      if (logs.length) {
+        setProgressMessage(`Staging Daily Logs 0/${logs.length}`);
+        await runThrottled(logs, async (chunk) => {
+          await base44.entities.StagedDailyLog.bulkCreate(chunk);
+        }, {
+          onProgress: ({ completed, total, batchSize }) => setProgressMessage(`Staging Daily Logs ${Math.min(completed + batchSize, total)}/${total}`),
+          onRetry: ({ delayMs }) => setProgressMessage(`Staging Daily Logs hit a Base44 rate limit. Retrying in ${Math.round(delayMs / 1000)}s...`),
+        });
+      }
+      if (events.length) {
+        setProgressMessage(`Staging Calendar Events 0/${events.length}`);
+        await runThrottled(events, async (chunk) => {
+          await base44.entities.StagedCalendarEvent.bulkCreate(chunk);
+        }, {
+          onProgress: ({ completed, total, batchSize }) => setProgressMessage(`Staging Calendar Events ${Math.min(completed + batchSize, total)}/${total}`),
+          onRetry: ({ delayMs }) => setProgressMessage(`Staging Calendar Events hit a Base44 rate limit. Retrying in ${Math.round(delayMs / 1000)}s...`),
+        });
+      }
 
       // Reload from DB so we have real IDs, then run cross-matching with real IDs
       const [dbJobs, dbLogsRaw, dbEventsRaw] = await Promise.all([
@@ -412,28 +523,39 @@ export default function BTImport() {
       const dbEvents = events.length ? matchEventsToJobs(dbEventsRaw, dbJobs) : dbEventsRaw;
 
       // Persist match results back to DB
-      await Promise.all([
-        ...dbLogs.filter(l => l.match_status !== 'unmatched').map(l =>
-          base44.entities.StagedDailyLog.update(l.id, {
-            match_status: l.match_status,
-            matched_staged_job_id: l.matched_staged_job_id || null,
-          })
-        ),
-        ...dbEvents.filter(e => e.match_status !== 'unmatched').map(e =>
-          base44.entities.StagedCalendarEvent.update(e.id, {
-            match_status: e.match_status,
-            matched_staged_job_id: e.matched_staged_job_id || null,
-          })
-        ),
-      ]);
+      const matchedLogs = dbLogs.filter(l => l.match_status !== 'unmatched');
+      const matchedEvents = dbEvents.filter(e => e.match_status !== 'unmatched');
+      if (matchedLogs.length) {
+        await runThrottled(matchedLogs, async (chunk) => {
+          for (const log of chunk) {
+            await base44.entities.StagedDailyLog.update(log.id, {
+              match_status: log.match_status,
+              matched_staged_job_id: log.matched_staged_job_id || null,
+            });
+          }
+        });
+      }
+      if (matchedEvents.length) {
+        await runThrottled(matchedEvents, async (chunk) => {
+          for (const event of chunk) {
+            await base44.entities.StagedCalendarEvent.update(event.id, {
+              match_status: event.match_status,
+              matched_job_id: event.matched_job_id || null,
+              matched_staged_job_id: event.matched_staged_job_id || null,
+            });
+          }
+        });
+      }
 
       // Update batch with counts
-      await base44.entities.ImportBatch.update(batch.id, {
+      await withRateLimitRetry(() => base44.entities.ImportBatch.update(batch.id, {
         dry_run_status: 'complete',
         total_rows: dbJobs.length + dbLogs.length + dbEvents.length,
         staged_count: dbJobs.length + dbLogs.length + dbEvents.length,
         warning_count: dbJobs.filter(j => safeParseJson(j.warnings, []).length > 0).length,
         error_count: allErrors.length,
+      }), {
+        onRetry: () => setProgressMessage('Finalizing import batch after Base44 rate limit...'),
       });
 
       setStagedJobs(dbJobs);
@@ -444,8 +566,9 @@ export default function BTImport() {
       setStep(STEPS.DRY_RUN);
       qc.invalidateQueries({ queryKey: ['import_batches'] });
     } catch (err) {
-      setParseError(err.message || 'Parse failed');
+      setParseError(isRateLimitError(err) ? RATE_LIMIT_ERROR_MESSAGE : (err.message || 'Parse failed'));
     } finally {
+      setProgressMessage('');
       setParsing(false);
     }
   }, [actorName, qc]);
@@ -453,17 +576,17 @@ export default function BTImport() {
   // ── Step 2: Review — approve/skip individual records ──────────────────────
 
   const handleJobStatusChange = useCallback(async (id, status) => {
-    await base44.entities.StagedJob.update(id, { review_status: status, reviewed_by: actorName });
+    await withRateLimitRetry(() => base44.entities.StagedJob.update(id, { review_status: status, reviewed_by: actorName }));
     setStagedJobs(prev => prev.map(j => j.id === id ? { ...j, review_status: status } : j));
   }, [actorName]);
 
   const handleLogStatusChange = useCallback(async (id, status) => {
-    await base44.entities.StagedDailyLog.update(id, { review_status: status, reviewed_by: actorName });
+    await withRateLimitRetry(() => base44.entities.StagedDailyLog.update(id, { review_status: status, reviewed_by: actorName }));
     setStagedLogs(prev => prev.map(l => l.id === id ? { ...l, review_status: status } : l));
   }, [actorName]);
 
   const handleEventStatusChange = useCallback(async (id, status) => {
-    await base44.entities.StagedCalendarEvent.update(id, { review_status: status, reviewed_by: actorName });
+    await withRateLimitRetry(() => base44.entities.StagedCalendarEvent.update(id, { review_status: status, reviewed_by: actorName }));
     setStagedEvents(prev => prev.map(e => e.id === id ? { ...e, review_status: status } : e));
   }, [actorName]);
 
@@ -615,6 +738,7 @@ export default function BTImport() {
               </div>
             </div>
             <BTImportUploader onFilesReady={handleFilesReady} loading={parsing} />
+            {progressMessage && <div className="pl-6 text-xs text-muted-foreground">{progressMessage}</div>}
             {parsing && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="w-4 h-4 animate-spin" /> Parsing files and staging records…


### PR DESCRIPTION
## Summary
- Adds text-layer parsing for Buildertrend monthly Schedule PDF exports.
- Stages parsed calendar events for dry-run review before any live import.
- Adds calendar diagnostics, deduplication, job matching, and office/internal review classification.
- Resolves conflicts with main while preserving import hardening, approved-count reload, skipped-row diagnostics, and rate-limit throttling.

## Validation
- npm run lint
- npm run build

## Safety
- No record deletion
- No Worker/R2 changes
- Live CalendarEvent creation still requires explicit confirm import