### PR TITLE
Lazy-load Buildertrend PDF parser dependency

### DIFF
--- a/src/lib/btPdfText.js
+++ b/src/lib/btPdfText.js
@@ -1,6 +1,14 @@
-import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+async function loadPdfJs() {
+  try {
+    return await import('pdfjs-dist');
+  } catch (error) {
+    console.error('[BTImport] Calendar PDF parser dependency failed to load:', error);
+    throw new Error('Calendar PDF parser dependency could not load in this environment.');
+  }
+}
 
 export async function extractPdfTextPages(file) {
+  const pdfjsLib = await loadPdfJs();
   const data = new Uint8Array(await file.arrayBuffer());
   const pdf = await pdfjsLib.getDocument({ data, disableWorker: true }).promise;
   const pages = [];

--- a/src/pages/BTImport.jsx
+++ b/src/pages/BTImport.jsx
@@ -29,7 +29,6 @@ import {
   matchEventsToJobs,
 } from '@/lib/btParsers';
 import { findBuildertrendImportedJobForLog, findExistingBuildertrendImportedJob } from '@/lib/jobHelpers';
-import { extractPdfTextPages } from '@/lib/btPdfText';
 import {
   importApprovedJobs,
   importApprovedDailyLogs,
@@ -490,8 +489,11 @@ export default function BTImport() {
       // Parse Calendar (same — match after DB insert)
       if (files.schedule_calendar) {
         const isPdf = files.schedule_calendar.type === 'application/pdf' || /\.pdf$/i.test(files.schedule_calendar.name);
+        const pdfTextPages = isPdf
+          ? await import('@/lib/btPdfText').then(module => module.extractPdfTextPages(files.schedule_calendar))
+          : null;
         const result = isPdf
-          ? parseCalendarPdfPages(await extractPdfTextPages(files.schedule_calendar), batch.id, files.schedule_calendar.name)
+          ? parseCalendarPdfPages(pdfTextPages, batch.id, files.schedule_calendar.name)
           : parseCalendarText(await readFileAsText(files.schedule_calendar), batch.id, files.schedule_calendar.name);
         liveJobsForMatching = liveJobsForMatching || await base44.entities.Job.list('-created_date');
         events = matchCalendarEventsToImportedJobs(result.staged, liveJobsForMatching);


### PR DESCRIPTION
## Summary
- Replaces the top-level PDF.js subpath import with PDF-only lazy loading.
- Uses the Vite-compatible bare `pdfjs-dist` package entry when a calendar PDF is uploaded.
- Keeps the BT Import page, CSV imports, and TXT imports loadable if the PDF parser dependency cannot load.
- Preserves calendar PDF dry-run parsing, diagnostics, dedupe, matching, office/internal review, throttling, and staged review flow.

## Validation
- npm run lint
- npm run build

## Safety
- No record deletion
- No Worker/R2 changes
- Live CalendarEvent creation still requires explicit confirm import