### PR TITLE
Fix job sidebar sticky layout

### DIFF
--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -24,21 +24,21 @@ export default function AppLayout({ children, title }) {
   const showJobWorkspace = !NO_JOB_WORKSPACE_PATHS.some(pattern => pattern.test(location.pathname));
 
   return (
-    <div className="app-shell flex flex-col">
+    <div className="app-shell flex h-full min-h-0 flex-col overflow-hidden">
       <AppTopBar onMenuOpen={() => setSidebarOpen(true)} title={title} />
       <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       {showJobWorkspace ? (
-        <div className="flex flex-1 min-h-0">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           <JobContextSidebar />
-          <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             <MobileJobContextBar />
-            <main className="app-main min-w-0">
+            <main className="app-main min-h-0 min-w-0 overflow-y-auto overscroll-contain">
               {children}
             </main>
           </div>
         </div>
       ) : (
-        <main className="app-main">
+        <main className="app-main min-h-0 overflow-y-auto overscroll-contain">
           {children}
         </main>
       )}

--- a/src/components/JobContextSidebar.jsx
+++ b/src/components/JobContextSidebar.jsx
@@ -217,7 +217,7 @@ export default function JobContextSidebar() {
   };
 
   return (
-    <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-80 shrink-0 self-start overflow-hidden border-r border-border bg-card lg:flex lg:flex-col">
+    <aside className="hidden h-full min-h-0 w-80 shrink-0 overflow-hidden border-r border-border bg-card lg:flex lg:flex-col">
       <div className="shrink-0 border-b border-border bg-card px-4 py-4">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
@@ -238,7 +238,7 @@ export default function JobContextSidebar() {
         <JobContextSummary job={currentJob} />
       </div>
 
-      <div className="sticky top-0 z-10 shrink-0 border-b border-border bg-card/95 px-4 py-3 backdrop-blur">
+      <div className="shrink-0 border-b border-border bg-card px-4 py-3">
         <label className="relative block">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
@@ -250,7 +250,7 @@ export default function JobContextSidebar() {
         </label>
       </div>
 
-      <div className="sticky top-[65px] z-10 shrink-0 space-y-2 border-b border-border bg-card/95 px-4 py-2 backdrop-blur">
+      <div className="shrink-0 space-y-2 border-b border-border bg-card px-4 py-2">
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-0.5 bg-muted rounded-lg p-0.5">
             {VIEW_TABS.map(tab => (


### PR DESCRIPTION
## Summary
- Fixes the Job Workspace sticky behavior by moving scrolling from the document/page flow into explicit viewport-height layout regions.
- Keeps the top app bar and Job Workspace visible while main content scrolls independently.
- Keeps the Job Workspace header/search/filter controls fixed above an independently scrolling job list.
- Preserves search/filter scroll reset behavior for the job list.

## Root Cause
- The sidebar was inside the same document/page scroll flow as the main content. Adding `position: sticky` to the sidebar was not enough because the AppLayout shell did not constrain the below-topbar region to the viewport or make the main content its own scroll container.

## Validation
- npm run lint
- npm run build

## Safety
- UI-only enhancement
- No job data mutations
- No import logic changes
- No Worker/R2 changes